### PR TITLE
Fix async context manager syntax in docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -71,7 +71,7 @@ both our queries for greetings and worlds in parallel!
 
 
     async def main():
-        with async aiosqlite.connect("greetings.db") as conn:
+        async with aiosqlite.connect("greetings.db") as conn:
             conn.row_factory = aiosqlite.Row
             # Parallel queries!!!
             greetings, worlds = await asyncio.gather(

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,7 +61,7 @@ Quick Example
 
     async def main():
        # Parallel queries!!!
-       with async aiosqlite.connect("greetings.db") as conn:
+       async with aiosqlite.connect("greetings.db") as conn:
            greetings, users = await asyncio.gather(
                queries.get_all_greetings(conn),
                queries.get_users_by_username(conn, username="willvaughn")


### PR DESCRIPTION
Hi, I noticed a couple typos in the examples provided by the docs where context managers were written `with async` rather than `async with` so I thought I'd fix em up to avoid confusion. Happy to base this PR off a different branch if you'd rather it go elsewhere.

Thanks for putting this lib together, I'm a big fan!