### PR TITLE
Adds file_path to QueryDatum

### DIFF
--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -5,7 +5,7 @@ from .types import QueryDatum, QueryDataTree, SQLOperationType
 
 
 def _create_methods(query_datum: QueryDatum, is_aio=True) -> List[Tuple[str, Callable]]:
-    query_name, doc_comments, operation_type, sql, record_class = query_datum
+    query_name, doc_comments, operation_type, sql, file_path, record_class = query_datum
 
     if is_aio:
 

--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -60,6 +60,7 @@ def _create_methods(query_datum: QueryDatum, is_aio=True) -> List[Tuple[str, Cal
     fn.__name__ = query_name
     fn.__doc__ = doc_comments
     fn.sql = sql
+    fn.file_path = file_path
 
     ctx_mgr_method_name = f"{query_name}_cursor"
 
@@ -70,6 +71,7 @@ def _create_methods(query_datum: QueryDatum, is_aio=True) -> List[Tuple[str, Cal
     ctx_mgr.__name__ = ctx_mgr_method_name
     ctx_mgr.__doc__ = doc_comments
     ctx_mgr.sql = sql
+    ctx_mgr.file_path = file_path
 
     if operation_type == SQLOperationType.SELECT:
         return [(query_name, fn), (ctx_mgr_method_name, ctx_mgr)]

--- a/aiosql/query_loader.py
+++ b/aiosql/query_loader.py
@@ -17,7 +17,7 @@ class QueryLoader:
         self.driver_adapter = driver_adapter
         self.record_classes = record_classes if record_classes is not None else {}
 
-    def _make_query_datum(self, query_str: str):
+    def _make_query_datum(self, query_str: str, file_path: Path):
         lines = query_str.strip().splitlines()
         query_name = lines[0].replace("-", "_")
 
@@ -65,18 +65,18 @@ class QueryLoader:
         sql = self.driver_adapter.process_sql(query_name, operation_type, sql)
         record_class = self.record_classes.get(record_class_name)
 
-        return QueryDatum(query_name, doc_comments, operation_type, sql, record_class)
+        return QueryDatum(query_name, doc_comments, operation_type, sql, file_path, record_class)
 
-    def load_query_data_from_sql(self, sql: str) -> List[QueryDatum]:
+    def load_query_data_from_sql(self, sql: str, file_path: Path) -> List[QueryDatum]:
         query_data = []
         for query_sql_str in query_name_definition_pattern.split(sql):
             if not empty_pattern.match(query_sql_str):
-                query_data.append(self._make_query_datum(query_sql_str))
+                query_data.append(self._make_query_datum(query_sql_str, file_path))
         return query_data
 
     def load_query_data_from_file(self, file_path: Path) -> List[QueryDatum]:
         with file_path.open() as fp:
-            return self.load_query_data_from_sql(fp.read())
+            return self.load_query_data_from_sql(fp.read(), file_path)
 
     def load_query_data_from_dir_path(self, dir_path) -> QueryDataTree:
         if not dir_path.is_dir():

--- a/aiosql/types.py
+++ b/aiosql/types.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from pathlib import Path
 from typing import Dict, Union, NamedTuple, Any
 
 
@@ -19,6 +20,7 @@ class QueryDatum(NamedTuple):
     doc_comments: str
     operation_type: SQLOperationType
     sql: str
+    file_path: Path
     record_class: Any = None
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ def populate_sqlite3_db(db_path):
                 firstname integer not null,
                 lastname text not null
             );
-            
+
             create table blogs (
                 blogid integer not null primary key,
                 userid integer not null,
@@ -116,3 +116,24 @@ def pg_conn(postgresql):
 def pg_dsn(pg_conn):
     p = pg_conn.get_dsn_parameters()
     return f"postgres://{p['user']}@{p['host']}:{p['port']}/{p['dbname']}"
+
+
+blogs_files_fn = [
+    ("blogs", "blogs.sql", ["publish_blog", "remove_blog", "get_user_blogs"]),
+    (
+        "blogs",
+        "blogs_pg.sql",
+        ["pg_get_blogs_published_after", "pg_publish_blog", "pg_bulk_publish"],
+    ),
+    ("blogs", "blogs_sqlite.sql", ["sqlite_get_blogs_published_after", "sqlite_bulk_publish"]),
+    ("users", "users.sql", ["get_all", "get_by_username", "get_by_lastname", "get_all_sorted"]),
+]
+
+
+@pytest.mark.parametrize("dir, file, functions", blogs_files_fn)
+def test_introspected_queries_path(sqlite3_conn, queries, dir, file, functions):
+    for fn in functions:
+        assert (
+            queries.__getattribute__(dir).__getattribute__(fn).file_path
+            == Path(__file__).parent / "blogdb" / "sql" / dir / file
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,24 +116,3 @@ def pg_conn(postgresql):
 def pg_dsn(pg_conn):
     p = pg_conn.get_dsn_parameters()
     return f"postgres://{p['user']}@{p['host']}:{p['port']}/{p['dbname']}"
-
-
-blogs_files_fn = [
-    ("blogs", "blogs.sql", ["publish_blog", "remove_blog", "get_user_blogs"]),
-    (
-        "blogs",
-        "blogs_pg.sql",
-        ["pg_get_blogs_published_after", "pg_publish_blog", "pg_bulk_publish"],
-    ),
-    ("blogs", "blogs_sqlite.sql", ["sqlite_get_blogs_published_after", "sqlite_bulk_publish"]),
-    ("users", "users.sql", ["get_all", "get_by_username", "get_by_lastname", "get_all_sorted"]),
-]
-
-
-@pytest.mark.parametrize("dir, file, functions", blogs_files_fn)
-def test_introspected_queries_path(sqlite3_conn, queries, dir, file, functions):
-    for fn in functions:
-        assert (
-            queries.__getattribute__(dir).__getattribute__(fn).file_path
-            == Path(__file__).parent / "blogdb" / "sql" / dir / file
-        )

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -1,0 +1,33 @@
+import pytest
+
+from tests.conftest import BLOGDB_PATH
+from tests.test_aiosqlite import aiosqlite_queries
+from tests.test_asyncpg import asyncpg_queries
+from tests.test_psycopg2 import psycopg2_queries
+from tests.test_sqlite3 import sqlite3_queries
+
+blogs_files_fn = [
+    ("blogs", "blogs.sql", ["publish_blog", "remove_blog", "get_user_blogs"]),
+    (
+        "blogs",
+        "blogs_pg.sql",
+        ["pg_get_blogs_published_after", "pg_publish_blog", "pg_bulk_publish"],
+    ),
+    ("blogs", "blogs_sqlite.sql", ["sqlite_get_blogs_published_after", "sqlite_bulk_publish"]),
+    ("users", "users.sql", ["get_all", "get_by_username", "get_by_lastname", "get_all_sorted"]),
+]
+
+drivers = [
+(aiosqlite_queries()), (asyncpg_queries()), (psycopg2_queries()),(sqlite3_queries())
+]
+
+
+@pytest.mark.parametrize("queries", drivers)
+@pytest.mark.parametrize("dir, file, functions", blogs_files_fn)
+def test_introspected_queries_path(queries, dir, file, functions):
+
+    for fn in functions:
+        assert (
+            queries.__getattribute__(dir).__getattribute__(fn).file_path
+            == BLOGDB_PATH / "sql" / dir / file
+        )

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -1,4 +1,4 @@
-from pathlib import Path, PosixPath
+from pathlib import Path
 from typing import NamedTuple
 
 import aiosql
@@ -24,27 +24,6 @@ def dict_factory(cursor, row):
 def queries():
     p = Path(__file__).parent / "blogdb" / "sql"
     return aiosql.from_path(p, "sqlite3", RECORD_CLASSES)
-
-
-blogs_files_fn = [
-    ("blogs", "blogs.sql", ["publish_blog", "remove_blog", "get_user_blogs"]),
-    (
-        "blogs",
-        "blogs_pg.sql",
-        ["pg_get_blogs_published_after", "pg_publish_blog", "pg_bulk_publish"],
-    ),
-    ("blogs", "blogs_sqlite.sql", ["sqlite_get_blogs_published_after", "sqlite_bulk_publish"]),
-    ("users", "users.sql", ["get_all", "get_by_username", "get_by_lastname", "get_all_sorted"]),
-]
-
-
-@pytest.mark.parametrize("dir, file, functions", blogs_files_fn)
-def test_introspected_queries_path(sqlite3_conn, queries, dir, file, functions):
-    for fn in functions:
-        assert (
-            queries.__getattribute__(dir).__getattribute__(fn).file_path
-            == Path(__file__).parent / "blogdb" / "sql" / dir / file
-        )
 
 
 def test_record_query(sqlite3_conn, queries):

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -21,14 +21,14 @@ def dict_factory(cursor, row):
 
 
 @pytest.fixture()
-def queries():
+def sqlite3_queries():
     p = Path(__file__).parent / "blogdb" / "sql"
     return aiosql.from_path(p, "sqlite3", RECORD_CLASSES)
 
 
-def test_record_query(sqlite3_conn, queries):
+def test_record_query(sqlite3_conn, sqlite3_queries):
     sqlite3_conn.row_factory = dict_factory
-    actual = queries.users.get_all(sqlite3_conn)
+    actual = sqlite3_queries.users.get_all(sqlite3_conn)
 
     assert len(actual) == 3
     assert actual[0] == {
@@ -39,15 +39,15 @@ def test_record_query(sqlite3_conn, queries):
     }
 
 
-def test_parameterized_query(sqlite3_conn, queries):
-    actual = queries.users.get_by_lastname(sqlite3_conn, lastname="Doe")
+def test_parameterized_query(sqlite3_conn, sqlite3_queries):
+    actual = sqlite3_queries.users.get_by_lastname(sqlite3_conn, lastname="Doe")
     expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
     assert actual == expected
 
 
-def test_parameterized_record_query(sqlite3_conn, queries):
+def test_parameterized_record_query(sqlite3_conn, sqlite3_queries):
     sqlite3_conn.row_factory = dict_factory
-    actual = queries.blogs.sqlite_get_blogs_published_after(sqlite3_conn, published="2018-01-01")
+    actual = sqlite3_queries.blogs.sqlite_get_blogs_published_after(sqlite3_conn, published="2018-01-01")
 
     expected = [
         {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
@@ -57,8 +57,8 @@ def test_parameterized_record_query(sqlite3_conn, queries):
     assert actual == expected
 
 
-def test_record_class_query(sqlite3_conn, queries):
-    actual = queries.blogs.get_user_blogs(sqlite3_conn, userid=1)
+def test_record_class_query(sqlite3_conn, sqlite3_queries):
+    actual = sqlite3_queries.blogs.get_user_blogs(sqlite3_conn, userid=1)
     expected = [
         UserBlogSummary(title="How to make a pie.", published="2018-11-23"),
         UserBlogSummary(title="What I did Today", published="2017-07-28"),
@@ -68,22 +68,22 @@ def test_record_class_query(sqlite3_conn, queries):
     assert actual == expected
 
 
-def test_select_cursor_context_manager(sqlite3_conn, queries):
-    with queries.blogs.get_user_blogs_cursor(sqlite3_conn, userid=1) as cursor:
+def test_select_cursor_context_manager(sqlite3_conn, sqlite3_queries):
+    with sqlite3_queries.blogs.get_user_blogs_cursor(sqlite3_conn, userid=1) as cursor:
         actual = cursor.fetchall()
         expected = [("How to make a pie.", "2018-11-23"), ("What I did Today", "2017-07-28")]
         assert actual == expected
 
 
-def test_select_one(sqlite3_conn, queries):
-    actual = queries.users.get_by_username(sqlite3_conn, username="johndoe")
+def test_select_one(sqlite3_conn, sqlite3_queries):
+    actual = sqlite3_queries.users.get_by_username(sqlite3_conn, username="johndoe")
     expected = (2, "johndoe", "John", "Doe")
     assert actual == expected
 
 
-def test_insert_returning(sqlite3_conn, queries):
+def test_insert_returning(sqlite3_conn, sqlite3_queries):
     with sqlite3_conn:
-        blogid = queries.blogs.publish_blog(
+        blogid = sqlite3_queries.blogs.publish_blog(
             sqlite3_conn,
             userid=2,
             title="My first blog",
@@ -106,16 +106,16 @@ def test_insert_returning(sqlite3_conn, queries):
     assert actual == expected
 
 
-def test_delete(sqlite3_conn, queries):
+def test_delete(sqlite3_conn, sqlite3_queries):
     # Removing the "janedoe" blog titled "Testing"
-    actual = queries.blogs.remove_blog(sqlite3_conn, blogid=2)
+    actual = sqlite3_queries.blogs.remove_blog(sqlite3_conn, blogid=2)
     assert actual is None
 
-    janes_blogs = queries.blogs.get_user_blogs(sqlite3_conn, userid=3)
+    janes_blogs = sqlite3_queries.blogs.get_user_blogs(sqlite3_conn, userid=3)
     assert len(janes_blogs) == 0
 
 
-def test_insert_many(sqlite3_conn, queries):
+def test_insert_many(sqlite3_conn, sqlite3_queries):
     blogs = [
         (2, "Blog Part 1", "content - 1", "2018-12-04"),
         (2, "Blog Part 2", "content - 2", "2018-12-05"),
@@ -123,10 +123,10 @@ def test_insert_many(sqlite3_conn, queries):
     ]
 
     with sqlite3_conn:
-        actual = queries.blogs.sqlite_bulk_publish(sqlite3_conn, blogs)
+        actual = sqlite3_queries.blogs.sqlite_bulk_publish(sqlite3_conn, blogs)
         assert actual is None
 
-        johns_blogs = queries.blogs.get_user_blogs(sqlite3_conn, userid=2)
+        johns_blogs = sqlite3_queries.blogs.get_user_blogs(sqlite3_conn, userid=2)
         assert johns_blogs == [
             ("Blog Part 3", "2018-12-06"),
             ("Blog Part 2", "2018-12-05"),

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -1,4 +1,4 @@
-from pathlib import Path
+from pathlib import Path, PosixPath
 from typing import NamedTuple
 
 import aiosql
@@ -24,6 +24,27 @@ def dict_factory(cursor, row):
 def queries():
     p = Path(__file__).parent / "blogdb" / "sql"
     return aiosql.from_path(p, "sqlite3", RECORD_CLASSES)
+
+
+blogs_files_fn = [
+    ("blogs", "blogs.sql", ["publish_blog", "remove_blog", "get_user_blogs"]),
+    (
+        "blogs",
+        "blogs_pg.sql",
+        ["pg_get_blogs_published_after", "pg_publish_blog", "pg_bulk_publish"],
+    ),
+    ("blogs", "blogs_sqlite.sql", ["sqlite_get_blogs_published_after", "sqlite_bulk_publish"]),
+    ("users", "users.sql", ["get_all", "get_by_username", "get_by_lastname", "get_all_sorted"]),
+]
+
+
+@pytest.mark.parametrize("dir, file, functions", blogs_files_fn)
+def test_introspected_queries_path(sqlite3_conn, queries, dir, file, functions):
+    for fn in functions:
+        assert (
+            queries.__getattribute__(dir).__getattribute__(fn).file_path
+            == Path(__file__).parent / "blogdb" / "sql" / dir / file
+        )
 
 
 def test_record_query(sqlite3_conn, queries):


### PR DESCRIPTION
For discussion only, not married to it, but I felt it's more useful to see it in action.

I'm in the process of writing a small CLI utility to help migrations, powered by aiosql and I would need to be able, given a function name created by `aiosql`, to get the file_path it was generated from.

So I added a `.file_path` to a generated function (much like the existing `.sql`)

I added test_common.py that checks that new `.file_path` matches correctly the function is was created from, for that I renamed the `queries` fixtures in 

test_asyncpg.py > asyncpg_queries
test_aiosqlite.py > aiosqlite_queries
test_psycopg2.py > psycopg2_queries
test_sqlite3.py > sqlite3_queries