### PR TITLE
Allow defining record classes as a map of importable strings

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,6 +125,18 @@ class UserBlogSummary(NamedTuple):
 
 
 @pytest.fixture
-def record_classes():
+def _record_classes():
     return {"UserBlogSummary": UserBlogSummary}
 
+
+@pytest.fixture(params=["class", "import_path"])
+def record_classes(request, _record_classes):
+    if request.param == "class":
+        return _record_classes
+
+    elif request.param == "import_path":
+        return {
+            name: f"{klass.__module__}.{klass.__name__}" for name, klass in _record_classes.items()
+        }
+
+    raise RuntimeError("Unknown record_class type")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import csv
 import sqlite3
 from pathlib import Path
+from typing import NamedTuple
 
 import pytest
 
@@ -116,3 +117,14 @@ def pg_conn(postgresql):
 def pg_dsn(pg_conn):
     p = pg_conn.get_dsn_parameters()
     return f"postgres://{p['user']}@{p['host']}:{p['port']}/{p['dbname']}"
+
+
+class UserBlogSummary(NamedTuple):
+    title: str
+    published: str
+
+
+@pytest.fixture
+def record_classes():
+    return {"UserBlogSummary": UserBlogSummary}
+

--- a/tests/test_aiosqlite.py
+++ b/tests/test_aiosqlite.py
@@ -1,24 +1,17 @@
 import asyncio
 from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import aiosqlite
 import pytest
 
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: str
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+from conftest import UserBlogSummary
 
 
 @pytest.fixture()
-def queries():
+def queries(record_classes):
     dir_path = Path(__file__).parent / "blogdb/sql"
-    return aiosql.from_path(dir_path, "aiosqlite", RECORD_CLASSES)
+    return aiosql.from_path(dir_path, "aiosqlite", record_classes)
 
 
 def dict_factory(cursor, row):

--- a/tests/test_asyncpg.py
+++ b/tests/test_asyncpg.py
@@ -1,25 +1,18 @@
 import asyncio
 from datetime import date
 from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import asyncpg
 import pytest
 
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: date
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+from conftest import UserBlogSummary
 
 
 @pytest.fixture()
-def queries():
+def queries(record_classes):
     dir_path = Path(__file__).parent / "blogdb/sql"
-    return aiosql.from_path(dir_path, "asyncpg", RECORD_CLASSES)
+    return aiosql.from_path(dir_path, "asyncpg", record_classes)
 
 
 @pytest.mark.asyncio

--- a/tests/test_psycopg2.py
+++ b/tests/test_psycopg2.py
@@ -1,25 +1,18 @@
 from datetime import date
 from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import psycopg2
 import psycopg2.extras
 import pytest
 
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: date
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+from conftest import UserBlogSummary
 
 
 @pytest.fixture()
-def queries():
+def queries(record_classes):
     dir_path = Path(__file__).parent / "blogdb" / "sql"
-    return aiosql.from_path(dir_path, "psycopg2", RECORD_CLASSES)
+    return aiosql.from_path(dir_path, "psycopg2", record_classes)
 
 
 def test_record_query(pg_conn, queries):

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -1,16 +1,9 @@
 from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import pytest
 
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: str
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+from conftest import UserBlogSummary
 
 
 def dict_factory(cursor, row):
@@ -21,9 +14,9 @@ def dict_factory(cursor, row):
 
 
 @pytest.fixture()
-def queries():
+def queries(record_classes):
     p = Path(__file__).parent / "blogdb" / "sql"
-    return aiosql.from_path(p, "sqlite3", RECORD_CLASSES)
+    return aiosql.from_path(p, "sqlite3", record_classes)
 
 
 def test_record_query(sqlite3_conn, queries):


### PR DESCRIPTION
I was consistently coming to recursive imports (record classes wanted to use queries, queries wanted to use record classes) when defining queries.

This should allow you to define where a record class is, not what it is, and have it be imported when needed.