### PR TITLE
Strip sql string when building QueryDatum

### DIFF
--- a/aiosql/query_loader.py
+++ b/aiosql/query_loader.py
@@ -62,7 +62,7 @@ class QueryLoader:
                 sql += line + "\n"
 
         doc_comments = doc_comments.strip()
-        sql = self.driver_adapter.process_sql(query_name, operation_type, sql)
+        sql = self.driver_adapter.process_sql(query_name, operation_type, sql.strip())
         record_class = self.record_classes.get(record_class_name)
 
         return QueryDatum(query_name, doc_comments, operation_type, sql, record_class)


### PR DESCRIPTION
While trying out aiosql on a project already using anosql I noticed that the 'sql' attribute for Queries' method objects was not striped in aiosql in contrast with anosql (see https://github.com/honza/anosql/blob/1.0.2/anosql/core.py#L234). Perhaps this got lost in a refactoring? Stripping these strings seems nicer, so I suggest this simple change.
