### PR TITLE
SELECT_VALUE operation support

### DIFF
--- a/aiosql/adapters/aiosqlite.py
+++ b/aiosql/adapters/aiosqlite.py
@@ -38,6 +38,17 @@ class AioSQLiteAdapter:
         return result
 
     @staticmethod
+    async def select_value(conn, _query_name, sql, parameters, record_class=None):
+        async with conn.execute(sql, parameters) as cur:
+            result = await cur.fetchone()
+            if record_class is None:
+                result = result[0] if result else None
+            elif result is not None:
+                column_names = [c[0] for c in cur.description]
+                result = record_class(**dict(zip(column_names, result)))
+        return result
+
+    @staticmethod
     @aiocontextmanager
     async def select_cursor(conn, _query_name, sql, parameters):
         async with conn.execute(sql, parameters) as cur:

--- a/aiosql/adapters/asyncpg.py
+++ b/aiosql/adapters/asyncpg.py
@@ -86,6 +86,16 @@ class AsyncPGAdapter:
                 result = record_class(**dict(result))
         return result
 
+    async def select_value(self, conn, query_name, sql, parameters, record_class=None):
+        parameters = self.maybe_order_params(query_name, parameters)
+        async with MaybeAcquire(conn) as connection:
+            result = await connection.fetchrow(sql, *parameters)
+            if record_class is None:
+                result = result[0] if result else None
+            elif result is not None:
+                result = record_class(**dict(result))
+        return result
+
     @aiocontextmanager
     async def select_cursor(self, conn, query_name, sql, parameters):
         parameters = self.maybe_order_params(query_name, parameters)

--- a/aiosql/adapters/psycopg2.py
+++ b/aiosql/adapters/psycopg2.py
@@ -39,6 +39,18 @@ class PsycoPG2Adapter:
         return result
 
     @staticmethod
+    def select_value(conn, _query_name, sql, parameters, record_class=None):
+        with conn.cursor() as cur:
+            cur.execute(sql, parameters)
+            result = cur.fetchone()
+            if record_class is None:
+                result = result[0] if result else None
+            elif result is not None:
+                column_names = [c.name for c in cur.description]
+                result = record_class(**dict(zip(column_names, result)))
+        return result
+
+    @staticmethod
     @contextmanager
     def select_cursor(conn, _query_name, sql, parameters):
         with conn.cursor() as cur:

--- a/aiosql/adapters/sqlite3.py
+++ b/aiosql/adapters/sqlite3.py
@@ -41,6 +41,19 @@ class SQLite3DriverAdapter:
         return result
 
     @staticmethod
+    def select_value(conn, _query_name, sql, parameters, record_class=None):
+        cur = conn.cursor()
+        cur.execute(sql, parameters)
+        result = cur.fetchone()
+        if record_class is None:
+            result = result[0] if result else None
+        elif result is not None:
+            column_names = [c[0] for c in cur.description]
+            result = record_class(**dict(zip(column_names, result)))
+        cur.close()
+        return result
+
+    @staticmethod
     @contextmanager
     def select_cursor(conn, _query_name, sql, parameters):
         cur = conn.cursor()

--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -31,6 +31,10 @@ def _create_methods(query_datum: QueryDatum, is_aio=True) -> List[Tuple[str, Cal
                 return await self.driver_adapter.select_one(
                     conn, query_name, sql, parameters, record_class
                 )
+            elif operation_type == SQLOperationType.SELECT_VALUE:
+                return await self.driver_adapter.select_value(
+                    conn, query_name, sql, parameters, record_class
+                )
             else:
                 raise ValueError(f"Unknown op_type: {operation_type}")
 
@@ -52,6 +56,10 @@ def _create_methods(query_datum: QueryDatum, is_aio=True) -> List[Tuple[str, Cal
                 return self.driver_adapter.select(conn, query_name, sql, parameters, record_class)
             elif operation_type == SQLOperationType.SELECT_ONE:
                 return self.driver_adapter.select_one(
+                    conn, query_name, sql, parameters, record_class
+                )
+            elif operation_type == SQLOperationType.SELECT_VALUE:
+                return self.driver_adapter.select_value(
                     conn, query_name, sql, parameters, record_class
                 )
             else:

--- a/aiosql/query_loader.py
+++ b/aiosql/query_loader.py
@@ -36,6 +36,9 @@ class QueryLoader:
         elif query_name.endswith("^"):
             operation_type = SQLOperationType.SELECT_ONE
             query_name = query_name[:-1]
+        elif query_name.endswith("$"):
+            operation_type = SQLOperationType.SELECT_VALUE
+            query_name = query_name[:-1]
         else:
             operation_type = SQLOperationType.SELECT
 

--- a/aiosql/types.py
+++ b/aiosql/types.py
@@ -12,6 +12,7 @@ class SQLOperationType(Enum):
     SCRIPT = 3
     SELECT = 4
     SELECT_ONE = 5
+    SELECT_VALUE = 6
 
 
 class QueryDatum(NamedTuple):

--- a/docs/defining_queries.rst
+++ b/docs/defining_queries.rst
@@ -57,7 +57,7 @@ by the database driver.
 Select One Row with ``^``
 -------------------------
 
-The ``^`` operator will execute the query, and only return the first row of a result set. If there are now rows in the
+The ``^`` operator will execute the query, and only return the first row of a result set. If there are no rows in the
 result set it returns ``None``. When using a raw driver this is usually done with ``cur.fetchone()`` vs
 ``cur.fetchall()``. This is useful when you know there should be one, and exactly one record for your query. For
 instance, if you have a unique index on the username field in your users table so that no two users should ever share
@@ -75,6 +75,22 @@ list of rows with length of 1.
 The method generated is:
 
     - ``get_user_by_username(conn, username: str)``
+
+Select Single Value with ``$``
+------------------------------
+The ``$`` operator will execute the query, and only return the first value of the first row of a result set. If there
+are no rows in the result set it returns ``None``. This is implemented by returing the first element of the tuple
+returned by ``cur.fetchone()``. This is mostly useful for queries returning IDs, COUNTs or other aggregates.
+
+.. code-block:: sql
+
+    -- name: get-count$
+    select count(*) from users
+
+The method generated is:
+
+    - ``get_count(conn)``
+
 
 Insert/Update/Delete with ``!``
 -------------------------------

--- a/tests/blogdb/sql/users/users.sql
+++ b/tests/blogdb/sql/users/users.sql
@@ -24,3 +24,7 @@ order by username asc;
 -- name: get-all-sorted
 -- Get all user records sorted by username
 select * from users order by username asc;
+
+-- name: get-count$
+-- Get number of users
+select count(*) from users;

--- a/tests/test_aiosqlite.py
+++ b/tests/test_aiosqlite.py
@@ -166,3 +166,12 @@ async def test_async_methods(sqlite3_db_path, queries):
         {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
         {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_select_value(sqlite3_db_path, queries):
+    async with aiosqlite.connect(sqlite3_db_path) as conn:
+        actual = await queries.users.get_count(conn)
+
+    expected = 3
+    assert actual == expected

--- a/tests/test_asyncpg.py
+++ b/tests/test_asyncpg.py
@@ -189,3 +189,11 @@ async def test_async_methods(pg_dsn, queries):
         {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
         {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
     ]
+
+
+@pytest.mark.asyncio
+async def test_select_value(pg_dsn, queries):
+    conn = await asyncpg.connect(pg_dsn)
+    actual = await queries.users.get_count(conn)
+    expected = 3
+    assert actual == expected

--- a/tests/test_psycopg2.py
+++ b/tests/test_psycopg2.py
@@ -147,3 +147,9 @@ def test_insert_many(pg_conn, queries):
             ("Blog Part 2", date(2018, 12, 5)),
             ("Blog Part 1", date(2018, 12, 4)),
         ]
+
+
+def test_select_value(pg_conn, queries):
+    actual = queries.users.get_count(pg_conn)
+    expected = 3
+    assert actual == expected

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -132,3 +132,9 @@ def test_insert_many(sqlite3_conn, queries):
             ("Blog Part 2", "2018-12-05"),
             ("Blog Part 1", "2018-12-04"),
         ]
+
+
+def test_select_value(sqlite3_conn, queries):
+    actual = queries.users.get_count(sqlite3_conn)
+    expected = 3
+    assert actual == expected


### PR DESCRIPTION
As requested in #11 and also missed by myself I started implementing support for queries returning only a single value. Up for discussion:

- Is `$` as a operation type prefix fine. Any other preferences?
- Is the implementation I provided for the `AioSQLiteAdapter` method `select_value` the right way to go forward?

I'll extend this pull request with implementations for the other adapters as soon as I get feedback no my questions.