### PR TITLE
Another Python SQLite Wrapper (APSW) support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,12 @@ python:
 before_install:
   - pip install -U pip
   - pip install poetry
-install: poetry install
+install:
+  - poetry install
+  - >-
+    poetry run pip install https://github.com/rogerbinns/apsw/releases/download/3.32.2-r1/apsw-3.32.2-r1.zip
+    --global-option=fetch --global-option=--version --global-option=3.32.2 --global-option=--all
+    --global-option=build --global-option=--enable-all-extensions
 script:
   - mypy .
   - black aiosql tests --check

--- a/aiosql/adapters/apsw.py
+++ b/aiosql/adapters/apsw.py
@@ -1,0 +1,71 @@
+from contextlib import contextmanager
+
+
+def _record_generator(cur, sql, parameters, record_class):
+    """Generate records for each row returned by the query. This function is necessary because the
+    cursor description is only available during query execution and not afterwards. The description
+    is cached inside APSW, so it is cheap to call getdescription repeatedly.
+    """
+    yield from (
+        record_class(**dict(zip((c[0] for c in cur.getdescription()), row)))
+        for row in cur.execute(sql, parameters)
+    )
+
+
+class APSWDriverAdapter:
+    @staticmethod
+    def process_sql(_query_name, _op_type, sql):
+        """Pass through function because the ``apsw`` driver already handles the :var_name
+        "named style" syntax used by aiosql variables. Note, it will also accept "qmark style"
+        variables.
+
+        Args:
+            _query_name (str): The name of the sql query. Unused.
+            _op_type (aiosql.SQLOperationType): The type of SQL operation performed by the sql.
+            sql (str): The sql as written before processing.
+
+        Returns:
+            str: Original SQL text unchanged.
+        """
+        return sql
+
+    @staticmethod
+    def select(conn, _query_name, sql, parameters, record_class=None):
+        cur = conn.cursor()
+        if record_class is not None:
+            results = _record_generator(cur, sql, parameters, record_class)
+        else:
+            results = cur.execute(sql, parameters)
+        return list(results)
+
+    @staticmethod
+    def select_one(conn, _query_name, sql, parameters, record_class=None):
+        cur = conn.cursor()
+        if record_class is not None:
+            return next(_record_generator(cur, sql, parameters, record_class), None,)
+        cur.execute(sql, parameters)
+        return cur.fetchone()
+
+    @staticmethod
+    @contextmanager
+    def select_cursor(conn, _query_name, sql, parameters):
+        cur = conn.cursor()
+        cur.execute(sql, parameters)
+        yield cur
+
+    @staticmethod
+    def insert_update_delete(conn, _query_name, sql, parameters):
+        conn.cursor().execute(sql, parameters)
+
+    @staticmethod
+    def insert_update_delete_many(conn, _query_name, sql, parameters):
+        conn.cursor().executemany(sql, parameters)
+
+    @staticmethod
+    def insert_returning(conn, _query_name, sql, parameters):
+        conn.cursor().execute(sql, parameters)
+        return conn.last_insert_rowid()
+
+    @staticmethod
+    def execute_script(conn, sql):
+        conn.cursor().execute(sql)

--- a/aiosql/aiosql.py
+++ b/aiosql/aiosql.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Callable, Dict, Optional, Type, Union
 
 from .adapters.aiosqlite import AioSQLiteAdapter
+from .adapters.apsw import APSWDriverAdapter
 from .adapters.asyncpg import AsyncPGAdapter
 from .adapters.psycopg2 import PsycoPG2Adapter
 from .adapters.sqlite3 import SQLite3DriverAdapter
@@ -13,6 +14,7 @@ from .types import DriverAdapterProtocol
 
 _ADAPTERS: Dict[str, Callable[..., DriverAdapterProtocol]] = {
     "aiosqlite": AioSQLiteAdapter,
+    "apsw": APSWDriverAdapter,
     "asyncpg": AsyncPGAdapter,
     "psycopg2": PsycoPG2Adapter,
     "sqlite3": SQLite3DriverAdapter,
@@ -100,8 +102,8 @@ def from_path(
 
     * **sql_path** - Path to a `.sql` file or directory containing `.sql` files.
     * **driver_adapter** - Either a string to designate one of the aiosql built-in database driver
-    adapters. One of "sqlite3", "psycopg2", "aiosqlite", or "asyncpg". If you have defined your own
-    adapter class, you may pass its constructor.
+    adapters. One of "apsw", "sqlite3", "psycopg2", "aiosqlite", or "asyncpg". If you have defined
+    your own adapter class, you may pass its constructor.
     * **record_classes** - *(optional)* **DEPRECATED** Mapping of strings used in "record_class"
     declarations to the python classes which aiosql should use when marshaling SQL results.
     * **loader_cls** - *(optional)* Custom constructor for `QueryLoader` extensions.

--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -102,8 +102,8 @@ class Queries:
     **Parameters:**
 
     * **driver_adapter** - Either a string to designate one of the aiosql built-in database driver
-    adapters. One of "sqlite3", "psycopg2", "aiosqlite", or "asyncpg". If you have defined your
-    own adapter class, you can pass it's constructor.
+    adapters. One of "apsw", "sqlite3", "psycopg2", "aiosqlite", or "asyncpg". If you have defined
+    your own adapter class, you can pass it's constructor.
     """
 
     def __init__(self, driver_adapter: DriverAdapterProtocol):

--- a/tests/blogdb/sql/users/users_apsw.sql
+++ b/tests/blogdb/sql/users/users_apsw.sql
@@ -1,0 +1,8 @@
+-- name: get-record-by-username^
+-- record_class: UserSummary
+select userid,
+       username,
+       firstname,
+       lastname
+  from users
+ where username = :username;

--- a/tests/test_apsw.py
+++ b/tests/test_apsw.py
@@ -1,0 +1,147 @@
+from pathlib import Path
+from typing import NamedTuple
+
+import aiosql
+import pytest
+
+
+class UserSummary(NamedTuple):
+    userid: int
+    username: str
+    firstname: str
+    lastname: str
+
+
+class UserBlogSummary(NamedTuple):
+    title: str
+    published: str
+
+
+RECORD_CLASSES = {"UserSummary": UserSummary, "UserBlogSummary": UserBlogSummary}
+
+
+def dict_factory(cursor, row):
+    d = {}
+    for idx, col in enumerate(cursor.description):
+        d[col[0]] = row[idx]
+    return d
+
+
+@pytest.fixture()
+def queries():
+    p = Path(__file__).parent / "blogdb" / "sql"
+    return aiosql.from_path(p, "apsw", RECORD_CLASSES)
+
+
+def test_record_query(apsw_conn, queries):
+    apsw_conn.setrowtrace(dict_factory)
+    actual = queries.users.get_all(apsw_conn)
+
+    assert len(actual) == 3
+    assert actual[0] == {
+        "userid": 1,
+        "username": "bobsmith",
+        "firstname": "Bob",
+        "lastname": "Smith",
+    }
+
+
+def test_parameterized_query(apsw_conn, queries):
+    actual = queries.users.get_by_lastname(apsw_conn, lastname="Doe")
+    expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
+    assert actual == expected
+
+
+def test_parameterized_record_query(apsw_conn, queries):
+    apsw_conn.setrowtrace(dict_factory)
+    actual = queries.blogs.sqlite_get_blogs_published_after(apsw_conn, published="2018-01-01")
+
+    expected = [
+        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
+        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
+    ]
+
+    assert actual == expected
+
+
+def test_record_class_query(apsw_conn, queries):
+    actual = queries.blogs.get_user_blogs(apsw_conn, userid=1)
+    expected = [
+        UserBlogSummary(title="How to make a pie.", published="2018-11-23"),
+        UserBlogSummary(title="What I did Today", published="2017-07-28"),
+    ]
+
+    assert all(isinstance(row, UserBlogSummary) for row in actual)
+    assert actual == expected
+
+
+def test_select_cursor_context_manager(apsw_conn, queries):
+    with queries.blogs.get_user_blogs_cursor(apsw_conn, userid=1) as cursor:
+        actual = cursor.fetchall()
+        expected = [("How to make a pie.", "2018-11-23"), ("What I did Today", "2017-07-28")]
+        assert actual == expected
+
+
+def test_select_one(apsw_conn, queries):
+    actual = queries.users.get_by_username(apsw_conn, username="johndoe")
+    expected = (2, "johndoe", "John", "Doe")
+    assert actual == expected
+
+
+def test_select_one_record(apsw_conn, queries):
+    actual = queries.users.get_record_by_username(apsw_conn, username="johndoe")
+    expected = UserSummary(2, "johndoe", "John", "Doe")
+    assert actual == expected
+
+
+def test_insert_returning(apsw_conn, queries):
+    with apsw_conn:
+        blogid = queries.blogs.publish_blog(
+            apsw_conn,
+            userid=2,
+            title="My first blog",
+            content="Hello, World!",
+            published="2018-12-04",
+        )
+    cur = apsw_conn.cursor()
+    cur.execute(
+        """\
+        select title
+          from blogs
+         where blogid = ?;
+    """,
+        (blogid,),
+    )
+    actual = cur.fetchone()
+    cur.close()
+    expected = ("My first blog",)
+
+    assert actual == expected
+
+
+def test_delete(apsw_conn, queries):
+    # Removing the "janedoe" blog titled "Testing"
+    actual = queries.blogs.remove_blog(apsw_conn, blogid=2)
+    assert actual is None
+
+    janes_blogs = queries.blogs.get_user_blogs(apsw_conn, userid=3)
+    assert len(janes_blogs) == 0
+
+
+def test_insert_many(apsw_conn, queries):
+    blogs = [
+        (2, "Blog Part 1", "content - 1", "2018-12-04"),
+        (2, "Blog Part 2", "content - 2", "2018-12-05"),
+        (2, "Blog Part 3", "content - 3", "2018-12-06"),
+    ]
+
+    with apsw_conn:
+        actual = queries.blogs.sqlite_bulk_publish(apsw_conn, blogs)
+        assert actual is None
+
+        johns_blogs = queries.blogs.get_user_blogs(apsw_conn, userid=2)
+        assert johns_blogs == [
+            ("Blog Part 3", "2018-12-06"),
+            ("Blog Part 2", "2018-12-05"),
+            ("Blog Part 1", "2018-12-04"),
+        ]


### PR DESCRIPTION
[Another Python SQLite Wrapper (APSW)](https://github.com/rogerbinns/apsw) is an alternative to the built-in sqlite3 module. As well as more closely following SQLite's C API, APSW allows the use of newer SQLite versions than the system version. This can be a major boon on LTS Linux distributions.

The API is similar enough that I could quickly implement an adapter by tweaking the one for sqlite3.

The only real challenge was that cursor descriptions are only available during query execution, unlike in the sqlite3 module where they are available afterwards. I resolved this with the `_record_generator` function, but perhaps there is a better way.

I added a test case for `select_one` with a `record_class`, because that branch did not seem to be covered. It's currently defined in `users_apsw.sql`, but perhaps it should be promoted all-adapter suite.

There is one potential blocker: APSW is not easily installed using poetry. [APSW is not available through PyPI](https://rogerbinns.github.io/apsw/download.html#easy-install-pip-pypi). There is an [apsw package](https://pypi.org/project/apsw/) on PyPI, but it should not be used. It is not controlled by the author of APSW and is several years out of date.

It is possible to [install APSW using `pip`](https://rogerbinns.github.io/apsw/download.html#i-really-want-to-use-pip), and the relevant options can be specified in a `requirements.txt` file, but this is not yet possible using poetry / `pyproject.toml`. See python-poetry/poetry#845 for details.

I was able to install APSW for testing by running the command from the APSW documentation, minus `--user`, through `poetry run`:

```sh
poetry run pip install https://github.com/rogerbinns/apsw/releases/download/3.32.2-r1/apsw-3.32.2-r1.zip \
--global-option=fetch --global-option=--version --global-option=3.32.2 --global-option=--all \
--global-option=build --global-option=--enable-all-extensions
```

I'm interested to hear whether you find this to be an acceptable workaround.