### PR TITLE
allow tests to execute against detached postgres instance (docker/RDS/etc)

### DIFF
--- a/tests/test_psycopg2.py
+++ b/tests/test_psycopg2.py
@@ -22,9 +22,8 @@ def queries():
     return aiosql.from_path(dir_path, "psycopg2", RECORD_CLASSES)
 
 
-def test_record_query(pg_conn, queries):
-    dsn = pg_conn.get_dsn_parameters()
-    with psycopg2.connect(**dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
+def test_record_query(pg_dsn, queries):
+    with psycopg2.connect(dsn=pg_dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
         actual = queries.users.get_all(conn)
 
     assert len(actual) == 3
@@ -42,9 +41,8 @@ def test_parameterized_query(pg_conn, queries):
     assert actual == expected
 
 
-def test_parameterized_record_query(pg_conn, queries):
-    dsn = pg_conn.get_dsn_parameters()
-    with psycopg2.connect(**dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
+def test_parameterized_record_query(pg_dsn, queries):
+    with psycopg2.connect(dsn=pg_dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
         actual = queries.blogs.pg_get_blogs_published_after(conn, published=date(2018, 1, 1))
 
     expected = [


### PR DESCRIPTION
Addresses #16 in a way that is different from how PR #15 did it.

Allows doing something like this with a docker container running postgres rather than having postgres installed on my machine.

```
docker run --rm --name pg-docker -e POSTGRES_PASSWORD=docker -d -p 5432:5432 -v $HOME/docker/volumes/postgres:/var/lib/postgresql/data  postgres:12-alpine
poetry run pytest --postgresql-detached --postgresql-password=docker
```