### PR TITLE
asyncpg variable processing collision

### DIFF
--- a/tests/blogdb/sql/blogs/blogs.sql
+++ b/tests/blogdb/sql/blogs/blogs.sql
@@ -25,3 +25,7 @@ delete from blogs where blogid = :blogid;
     from blogs
    where userid = :userid
 order by published desc;
+
+
+-- name: search
+select title from blogs where title = :title and published = :published;

--- a/tests/blogdb/sql/users/users.sql
+++ b/tests/blogdb/sql/users/users.sql
@@ -33,3 +33,12 @@ select * from users order by username asc;
 -- name: get-count$
 -- Get number of users
 select count(*) from users;
+
+
+-- name: search
+-- The reason firstname has a :title param is because this is used in a test
+-- for a bug in from https://github.com/nackjicholson/aiosql/issues/51
+-- There needs to be a duplicate variable name within a duplicate function,
+-- "search" in this case across two different sql files. The blogs.sql has
+-- another function "search" with a :title key as well.
+select username from users where firstname = :title and lastname = :lastname;


### PR DESCRIPTION
Introduces namespacing to fix the `var_replacements` collisions described by #51.

This is done in a way that does not introduce any breaking API changes for aiosql or the adapter interface's  `process_sql` method. The automated tests pass, and that certainly is a good sign, but this code could use some testing by someone who uses the library in a non-trivial way. I changed more code than I thought I would need to and I want to make sure there are no obvious regressions or new bugs prior to shipping a new patch version. 

The reason it was a bit more code than I thought it would be is because namespacing needs to happen when loading sql from files and that happens pretty far up toward the entry layer of the program. That information is then  punched all the way down to `process_sql` and any other adapter code. Also, everything still needs to work for people loading sql from a stirng, or from a single file. In those cases there really is no namespace.