### PR TITLE
Generate a Signature from SQL Parameters

### DIFF
--- a/aiosql/types.py
+++ b/aiosql/types.py
@@ -1,3 +1,4 @@
+import inspect
 from enum import Enum
 from typing import (
     Any,
@@ -32,10 +33,12 @@ class QueryDatum(NamedTuple):
     operation_type: SQLOperationType
     sql: str
     record_class: Any = None
+    signature: Optional[inspect.Signature] = None
 
 
 class QueryFn(Protocol):
     __name__: str
+    __signature__: Optional[inspect.Signature]
     sql: str
     operation: SQLOperationType
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,3 +1,4 @@
+import inspect
 from pathlib import Path
 from unittest import mock
 
@@ -61,3 +62,15 @@ def test_trailing_space_on_lines_does_not_error():
         aiosql.from_str(sql_str, "aiosqlite")
     except SQLParseException:
         pytest.fail("Raised SQLParseException due to trailing space in query.")
+
+
+def test_loading_query_signature():
+    sql_str = "-- name: get^\n" "select * from test where foo=:foo and bar=:bar"
+    queries = aiosql.from_str(sql_str, "aiosqlite")
+    assert queries.get.__signature__ == inspect.Signature(
+        [
+            inspect.Parameter("self", kind=inspect.Parameter.POSITIONAL_OR_KEYWORD),
+            inspect.Parameter("foo", kind=inspect.Parameter.KEYWORD_ONLY),
+            inspect.Parameter("bar", kind=inspect.Parameter.KEYWORD_ONLY),
+        ]
+    )


### PR DESCRIPTION
This change adds another step to building a QueryFn which attempts to generate a function signature from the query parameters.

This adds helpful introspection:

```python
>>> import inspect
>>> import aiosql
... 
... sql_str = (
...     "-- name: get^\n"
...     "select * from test where foo=:foo and bar=:bar"
... )
... queries = aiosql.from_str(sql_str, "aiosqlite")
>>> inspect.signature(queries.get)
<Signature (*, foo, bar)>
>>> help(queries.get)
Help on method get in module aiosql.queries:

async get(*, foo, bar) method of aiosql.queries.Queries instance
```

Interactive REPLs are able to provide hints/tooltips based on the signature as well.