### PR TITLE
Correctly detect empty string literals ('') in SQL source

### DIFF
--- a/aiosql/patterns.py
+++ b/aiosql/patterns.py
@@ -27,7 +27,7 @@ Pattern: Identifies SQL comments.
 
 var_pattern = re.compile(
     r'(?P<dblquote>"[^"]+")|'
-    r"(?P<quote>\'[^\']+\')|"
+    r"(?P<quote>\'[^\']*\')|"
     r"(?P<lead>[^:]):(?P<var_name>[\w-]+)(?P<trail>[^:]?)"
 )
 """

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -52,3 +52,31 @@ def test_var_pattern_does_not_require_semicolon_trail():
 
     expected = {"dblquote": None, "lead": " ", "quote": None, "trail": "", "var_name": "a"}
     assert groupdicts[0] == expected
+
+
+def test_var_pattern_handles_empty_sql_string_literals():
+    """Make sure SQL '' are treated correctly and don't cause a substitution to be skipped."""
+    sql = """
+        select blah
+          from foo
+         where lower(regexp_replace(blah,'\W','','g')) = lower(regexp_replace(:blah,'\W','','g'));"""
+
+    groupdicts = [m.groupdict() for m in var_pattern.finditer(sql)]
+
+    expected_single_quote_match = {
+        "dblquote": None,
+        "lead": None,
+        "quote": "''",
+        "trail": None,
+        "var_name": None,
+    }
+    assert groupdicts[1] == expected_single_quote_match
+
+    expected_var_match = {
+        "dblquote": None,
+        "lead": "(",
+        "quote": None,
+        "trail": ",",
+        "var_name": "blah",
+    }
+    assert groupdicts[3] == expected_var_match


### PR DESCRIPTION
In our project we had a query with the following line:
```sql
AND LOWER(REGEXP_REPLACE(company_name,'\W','','g')) = LOWER(REGEXP_REPLACE(:companyName,'\W','','g'))
```

aiosql did not detect the empty string literal `''` properly. So it treated the closing `'` as an opening quote, and then it treated `')) = LOWER(REGEXP_REPLACE(:companyName,'` as a string literal. Because of this, `:companyName` was not substituted in it.