### PR TITLE
Add MySQL support

### DIFF
--- a/aiosql/adapters/__init__.py
+++ b/aiosql/adapters/__init__.py
@@ -1,0 +1,19 @@
+# standard adapters
+from .pyformat import PyFormatAdapter
+from .generic import GenericAdapter
+from .sqlite3 import SQLite3Adapter
+from .psycopg import PsycoPGAdapter
+
+# async adapters
+from .aiosqlite import AioSQLiteAdapter
+from .asyncpg import AsyncPGAdapter
+
+# silence flake8 F401 warning:
+_ALL = [
+    PyFormatAdapter,
+    GenericAdapter,
+    SQLite3Adapter,
+    PsycoPGAdapter,
+    AioSQLiteAdapter,
+    AsyncPGAdapter,
+]

--- a/aiosql/aiosql.py
+++ b/aiosql/aiosql.py
@@ -16,8 +16,10 @@ from .types import DriverAdapterProtocol
 _ADAPTERS: Dict[str, Callable[..., DriverAdapterProtocol]] = {
     "aiosqlite": AioSQLiteAdapter,  # type: ignore
     "asyncpg": AsyncPGAdapter,  # type: ignore
+    "mysqldb": PyFormatAdapter,
     "psycopg": PsycoPGAdapter,
     "psycopg2": PsycoPGAdapter,
+    "pymysql": PyFormatAdapter,
     "sqlite3": SQLite3Adapter,
 }
 

--- a/dev-requirements.in
+++ b/dev-requirements.in
@@ -5,13 +5,17 @@ twine
 black==21.12b0
 pytest>=6,<7
 pytest-postgresql>=4
+pytest-mysql>=2
 aiosqlite>=0.16.0,<1
 asyncpg>=0.21.0,<1
 pytest-asyncio>=0.14.0,<1
 psycopg>=3
 psycopg2-binary>=2.8.6,<3
+psycopg2<3
 mypy>=0.790
 sphinx>=4,<5
 sphinx-rtd-theme>=0.5.2
 coverage
 # NO: flake8
+mysqlclient>=2
+pymysql>=1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -69,13 +69,19 @@ keyring==23.5.0
 markupsafe==2.1.1
     # via jinja2
 mirakuru==2.4.2
-    # via pytest-postgresql
+    # via
+    #   pytest-mysql
+    #   pytest-postgresql
 mypy==0.942
     # via -r dev-requirements.in
 mypy-extensions==0.4.3
     # via
     #   black
     #   mypy
+mysqlclient==2.1.0
+    # via
+    #   -r dev-requirements.in
+    #   pytest-mysql
 packaging==21.3
     # via
     #   bleach
@@ -95,8 +101,12 @@ pluggy==1.0.0
 port-for==0.6.2
     # via pytest-postgresql
 psutil==5.9.0
-    # via mirakuru
+    # via
+    #   pytest-mysql
+    #   pytest-postgresql
 psycopg==3.0.11
+    # via -r dev-requirements.in
+psycopg2==2.9.3
     # via -r dev-requirements.in
 psycopg2-binary==2.9.3
     # via -r dev-requirements.in
@@ -109,16 +119,21 @@ pygments==2.11.2
     #   readme-renderer
     #   rich
     #   sphinx
+pymysql==1.0.2
+    # via -r dev-requirements.in
 pyparsing==3.0.7
     # via packaging
 pytest==6.2.5
     # via
     #   -r dev-requirements.in
     #   pytest-asyncio
+    #   pytest-mysql
     #   pytest-postgresql
 pytest-asyncio==0.18.3
     # via -r dev-requirements.in
 pytest-postgresql==4.1.1
+    # via -r dev-requirements.in
+pytest-mysql==2.2.0
     # via -r dev-requirements.in
 pytz==2022.1
     # via babel

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,7 +9,10 @@ aiosql - Simple SQL in Python
 SQL is code. Write it, version control it, comment it, and run it using files. Writing your SQL code in Python programs as strings doesn't allow you to easily reuse them in SQL GUIs or CLI tools like psql. With aiosql you can organize your SQL statements in *.sql* files, load them into your python application as methods to call without losing the ability to use them as you would any other SQL file.
 
 This project supports standard and `asyncio <https://docs.python.org/3/library/asyncio.html>`__ based
-drivers for SQLite and PostgreSQL out of the box (`sqlite3 <https://docs.python.org/3/library/sqlite3.html>`__, `aiosqlite <https://aiosqlite.omnilib.dev/en/latest/?badge=latest>`__, `psycopg <https://www.psycopg.org/docs/>`__, `asyncpg <https://magicstack.github.io/asyncpg/current/>`__). Extensions to support other database drivers can be written by you! See: `Database Driver Adapters <./database-driver-adapters.md>`__
+drivers for SQLite (`sqlite3 <https://docs.python.org/3/library/sqlite3.html>`__, `aiosqlite <https://aiosqlite.omnilib.dev/en/latest/?badge=latest>`__),
+PostgreSQL (`psycopg <https://www.psycopg.org/docs/>`__, `asyncpg <https://magicstack.github.io/asyncpg/current/>`__)
+and MySQL (`PyMySQL <https://github.com/PyMySQL/PyMySQL/>`__, `mysqlclient <https://pypi.org/project/mysqlclient/>`__) out of the box.
+Extensions to support other database drivers can be written by you! See: `Database Driver Adapters <./database-driver-adapters.md>`__
 
 .. danger::
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-exclude = (build|venv)
+exclude = (build|venv)/
 
 [mypy-*.*]
 ignore_missing_imports = True

--- a/tests/blogdb/sql/blogs/blogs_mysqldb.sql
+++ b/tests/blogdb/sql/blogs/blogs_mysqldb.sql
@@ -1,0 +1,20 @@
+-- name: my-get-blogs-published-after
+-- Get all blogs by all authors published after the given date.
+    select b.title,
+           u.username,
+           DATE_FORMAT(b.published, '%Y-%m-%d %H:%M') as published
+      from blogs b
+inner join users u on b.userid = u.userid
+     where b.published >= :published
+  order by b.published desc;
+
+
+-- name: my-bulk-publish*!
+-- Insert many blogs at once
+insert into blogs (
+  userid,
+  title,
+  content,
+  published
+)
+values (%s, %s, %s, %s);

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,380 @@
+from pathlib import Path
+from typing import NamedTuple
+from datetime import date
+import shutil
+import asyncio
+
+import aiosql
+
+# for sqlite3
+def todate(year, month, day):
+    return f"{year}-{month:02}-{day:02}"
+
+
+def has_exec(cmd):
+    return shutil.which(cmd) is not None
+
+
+class UserBlogSummary(NamedTuple):
+    title: str
+    published: date
+
+
+RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+
+
+def queries(driver):
+    dir_path = Path(__file__).parent / "blogdb" / "sql"
+    return aiosql.from_path(dir_path, driver, RECORD_CLASSES)
+
+
+# run something on a connection without a schema
+def run_something(conn):
+    def sel12(cur):
+        cur.execute("SELECT 1, 'un' UNION SELECT 2, 'deux' ORDER BY 1")
+        res = cur.fetchall()
+        assert res == ((1, "un"), (2, "deux"))
+
+    cur = conn.cursor()
+    has_with = hasattr(cur, "__enter__")
+    sel12(cur)
+    cur.close()
+
+    if has_with:  # if available
+        with conn.cursor() as cur:
+            sel12(cur)
+
+    conn.commit()
+
+
+def run_record_query(conn, queries):
+    actual = queries.users.get_all(conn)
+    assert len(actual) == 3
+    assert actual[0] == {
+        "userid": 1,
+        "username": "bobsmith",
+        "firstname": "Bob",
+        "lastname": "Smith",
+    }
+
+
+def run_parameterized_query(conn, queries):
+    actual = queries.users.get_by_lastname(conn, lastname="Doe")
+    expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
+    # NOTE mysqldb returns a tuple instead of a list, hence the conversion
+    assert list(actual) == expected
+
+
+def run_parameterized_record_query(conn, queries, db, todate):
+    fun = (
+        queries.blogs.sqlite_get_blogs_published_after
+        if db == "sqlite"
+        else queries.blogs.pg_get_blogs_published_after
+        if db == "pg"
+        else queries.blogs.my_get_blogs_published_after
+    )
+
+    actual = fun(conn, published=todate(2018, 1, 1))
+
+    expected = [
+        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
+        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
+    ]
+
+    assert actual == expected
+
+
+def run_record_class_query(conn, queries, todate):
+    actual = queries.blogs.get_user_blogs(conn, userid=1)
+    expected = [
+        UserBlogSummary(title="How to make a pie.", published=todate(2018, 11, 23)),
+        UserBlogSummary(title="What I did Today", published=todate(2017, 7, 28)),
+    ]
+
+    assert all(isinstance(row, UserBlogSummary) for row in actual)
+    assert actual == expected
+
+    one = queries.blogs.get_latest_user_blog(conn, userid=1)
+    assert one == UserBlogSummary(title="How to make a pie.", published=todate(2018, 11, 23))
+
+
+def run_select_cursor_context_manager(conn, queries, todate):
+    with queries.blogs.get_user_blogs_cursor(conn, userid=1) as cursor:
+        actual = cursor.fetchall()
+        expected = [
+            ("How to make a pie.", todate(2018, 11, 23)),
+            ("What I did Today", todate(2017, 7, 28)),
+        ]
+        assert list(actual) == expected
+
+
+def run_select_one(conn, queries):
+    actual = queries.users.get_by_username(conn, username="johndoe")
+    expected = (2, "johndoe", "John", "Doe")
+    assert actual == expected
+
+
+def run_insert_returning(conn, queries, db, todate):
+    fun = (
+        queries.blogs.publish_blog
+        if db == "sqlite"
+        else queries.blogs.pg_publish_blog
+        if db == "pg"
+        else queries.blogs.my_publish_blog
+    )
+    query = (
+        "select blogid, title from blogs where blogid = %s;"
+        if db == "pg"
+        else "select blogid, title from blogs where blogid = ?;"
+    )
+
+    blogid = fun(
+        conn,
+        userid=2,
+        title="My first blog",
+        content="Hello, World!",
+        published=todate(2018, 12, 4),
+    )
+
+    # sqlite returns a number while pg query returns a tuple
+    if isinstance(blogid, tuple):
+        blogid, title = blogid
+    else:
+        blogid, title = blogid, "My first blog"
+
+    def check_cbt(cur, b, t):
+        cur.execute(query, (b,))
+        actual = cur.fetchone()
+        assert actual == (b, t)
+
+    cur = conn.cursor()
+    has_with = hasattr(cur, "__enter__")
+    check_cbt(cur, blogid, title)
+    cur.close()
+
+    # try with if available
+    if has_with:
+        with conn.cursor() as cur:
+            check_cbt(cur, blogid, title)
+
+    if db == "pg":
+        res = queries.blogs.pg_no_publish(conn)
+        assert res is None
+
+
+def run_delete(conn, queries):
+    # Removing the "janedoe" blog titled "Testing"
+    actual = queries.blogs.remove_blog(conn, blogid=2)
+    assert actual == 1
+
+    janes_blogs = queries.blogs.get_user_blogs(conn, userid=3)
+    assert len(janes_blogs) == 0
+
+
+def run_insert_many(conn, queries, todate):
+    blogs = [
+        {
+            "userid": 2,
+            "title": "Blog Part 1",
+            "content": "content - 1",
+            "published": todate(2018, 12, 4),
+        },
+        {
+            "userid": 2,
+            "title": "Blog Part 2",
+            "content": "content - 2",
+            "published": todate(2018, 12, 5),
+        },
+        {
+            "userid": 2,
+            "title": "Blog Part 3",
+            "content": "content - 3",
+            "published": todate(2018, 12, 6),
+        },
+    ]
+
+    actual = queries.blogs.pg_bulk_publish(conn, blogs)
+    assert actual == 3
+
+    johns_blogs = queries.blogs.get_user_blogs(conn, userid=2)
+    assert johns_blogs == [
+        ("Blog Part 3", todate(2018, 12, 6)),
+        ("Blog Part 2", todate(2018, 12, 5)),
+        ("Blog Part 1", todate(2018, 12, 4)),
+    ]
+
+
+def run_select_value(conn, queries):
+    actual = queries.users.get_count(conn)
+    assert actual == 3
+
+
+#
+# Asynchronous tests
+#
+
+
+async def run_async_record_query(conn, queries):
+    actual = [dict(r) for r in await queries.users.get_all(conn)]
+
+    assert len(actual) == 3
+    assert actual[0] == {
+        "userid": 1,
+        "username": "bobsmith",
+        "firstname": "Bob",
+        "lastname": "Smith",
+    }
+
+
+async def run_async_parameterized_query(conn, queries, todate):
+    actual = await queries.blogs.get_user_blogs(conn, userid=1)
+    expected = [
+        ("How to make a pie.", todate(2018, 11, 23)),
+        ("What I did Today", todate(2017, 7, 28)),
+    ]
+    assert actual == expected
+
+
+async def run_async_parameterized_record_query(conn, queries, db, todate):
+    fun = (
+        queries.blogs.pg_get_blogs_published_after
+        if db == "pg"
+        else queries.blogs.sqlite_get_blogs_published_after
+    )
+    records = await fun(conn, published=todate(2018, 1, 1))
+
+    actual = [dict(rec) for rec in records]
+
+    expected = [
+        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
+        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
+    ]
+
+    assert actual == expected
+
+
+async def run_async_record_class_query(conn, queries, todate):
+    actual = await queries.blogs.get_user_blogs(conn, userid=1)
+
+    expected = [
+        UserBlogSummary(title="How to make a pie.", published=todate(2018, 11, 23)),
+        UserBlogSummary(title="What I did Today", published=todate(2017, 7, 28)),
+    ]
+
+    assert all(isinstance(row, UserBlogSummary) for row in actual)
+    assert actual == expected
+
+    one = await queries.blogs.get_latest_user_blog(conn, userid=1)
+    assert one == UserBlogSummary(title="How to make a pie.", published=todate(2018, 11, 23))
+
+
+async def run_async_select_cursor_context_manager(conn, queries, todate):
+    async with queries.blogs.get_user_blogs_cursor(conn, userid=1) as cursor:
+        actual = [tuple(rec) async for rec in cursor]
+        expected = [
+            ("How to make a pie.", todate(2018, 11, 23)),
+            ("What I did Today", todate(2017, 7, 28)),
+        ]
+        assert actual == expected
+
+
+async def run_async_select_one(conn, queries):
+    actual = await queries.users.get_by_username(conn, username="johndoe")
+    expected = (2, "johndoe", "John", "Doe")
+    assert actual == expected
+
+
+async def run_async_select_value(conn, queries):
+    actual = await queries.users.get_count(conn)
+    expected = 3
+    assert actual == expected
+
+
+async def run_async_insert_returning(conn, queries, db, todate):
+
+    fun = queries.blogs.pg_publish_blog if db == "pg" else queries.blogs.publish_blog
+
+    blogid = await fun(
+        conn,
+        userid=2,
+        title="My first blog",
+        content="Hello, World!",
+        published=todate(2018, 12, 4),
+    )
+
+    if db == "pg":
+        blogid, title = blogid
+    else:
+        blogid, title = blogid, "My first blog"
+
+    if db == "pg":
+        query = "select blogid, title from blogs where blogid = $1;"
+        actual = tuple(
+            await conn.fetchrow(
+                query,
+                blogid,
+            )
+        )
+    else:
+        query = "select blogid, title from blogs where blogid = :blogid;"
+        async with conn.execute(query, {"blogid": blogid}) as cur:
+            actual = await cur.fetchone()
+    assert actual == (blogid, title)
+
+
+async def run_async_delete(conn, queries):
+    # Removing the "janedoe" blog titled "Testing"
+    actual = await queries.blogs.remove_blog(conn, blogid=2)
+    assert actual is None
+
+    janes_blogs = await queries.blogs.get_user_blogs(conn, userid=3)
+    assert len(janes_blogs) == 0
+
+
+async def run_async_insert_many(conn, queries, todate):
+    blogs = [
+        {
+            "userid": 2,
+            "title": "Blog Part 1",
+            "content": "content - 1",
+            "published": todate(2018, 12, 4),
+        },
+        {
+            "userid": 2,
+            "title": "Blog Part 2",
+            "content": "content - 2",
+            "published": todate(2018, 12, 5),
+        },
+        {
+            "userid": 2,
+            "title": "Blog Part 3",
+            "content": "content - 3",
+            "published": todate(2018, 12, 6),
+        },
+    ]
+    actual = await queries.blogs.pg_bulk_publish(conn, blogs)
+    assert actual is None
+
+    johns_blogs = await queries.blogs.get_user_blogs(conn, userid=2)
+    assert johns_blogs == [
+        ("Blog Part 3", todate(2018, 12, 6)),
+        ("Blog Part 2", todate(2018, 12, 5)),
+        ("Blog Part 1", todate(2018, 12, 4)),
+    ]
+
+
+async def run_async_methods(conn, queries):
+    users, sorted_users = await asyncio.gather(
+        queries.users.get_all(conn), queries.users.get_all_sorted(conn)
+    )
+
+    assert [dict(u) for u in users] == [
+        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
+        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
+        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
+    ]
+    assert [dict(u) for u in sorted_users] == [
+        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
+        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
+        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
+    ]

--- a/tests/test_aiosqlite.py
+++ b/tests/test_aiosqlite.py
@@ -1,24 +1,13 @@
-import asyncio
-from pathlib import Path
-from typing import NamedTuple
-
 import aiosql
 import aiosqlite
+
 import pytest
-
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: str
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+import run_tests as t
 
 
 @pytest.fixture()
 def queries():
-    dir_path = Path(__file__).parent / "blogdb/sql"
-    return aiosql.from_path(dir_path, "aiosqlite", RECORD_CLASSES)
+    return t.queries("aiosqlite")
 
 
 def dict_factory(cursor, row):
@@ -32,152 +21,69 @@ def dict_factory(cursor, row):
 async def test_record_query(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
         conn.row_factory = dict_factory
-        actual = await queries.users.get_all(conn)
-
-        assert len(actual) == 3
-        assert actual[0] == {
-            "userid": 1,
-            "username": "bobsmith",
-            "firstname": "Bob",
-            "lastname": "Smith",
-        }
+        await t.run_async_record_query(conn, queries)
 
 
 @pytest.mark.asyncio
 async def test_parameterized_query(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        actual = await queries.blogs.get_user_blogs(conn, userid=1)
-        expected = [("How to make a pie.", "2018-11-23"), ("What I did Today", "2017-07-28")]
-        assert actual == expected
+        await t.run_async_parameterized_query(conn, queries, t.todate)
 
 
 @pytest.mark.asyncio
 async def test_parameterized_record_query(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
         conn.row_factory = dict_factory
-        actual = await queries.blogs.sqlite_get_blogs_published_after(conn, published="2018-01-01")
-
-        expected = [
-            {
-                "title": "How to make a pie.",
-                "username": "bobsmith",
-                "published": "2018-11-23 00:00",
-            },
-            {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
-        ]
-
-        assert actual == expected
+        await t.run_async_parameterized_record_query(conn, queries, "sqlite", t.todate)
 
 
 @pytest.mark.asyncio
 async def test_record_class_query(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        actual = await queries.blogs.get_user_blogs(conn, userid=1)
-        expected = [
-            UserBlogSummary(title="How to make a pie.", published="2018-11-23"),
-            UserBlogSummary(title="What I did Today", published="2017-07-28"),
-        ]
-
-        assert all(isinstance(row, UserBlogSummary) for row in actual)
-        assert actual == expected
-
-        one = await queries.blogs.get_latest_user_blog(conn, userid=1)
-        assert one == UserBlogSummary(title="How to make a pie.", published="2018-11-23")
+        await t.run_async_record_class_query(conn, queries, t.todate)
 
 
 @pytest.mark.asyncio
 async def test_select_cursor_context_manager(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        async with queries.blogs.get_user_blogs_cursor(conn, userid=1) as cursor:
-            actual = [row async for row in cursor]
-            expected = [("How to make a pie.", "2018-11-23"), ("What I did Today", "2017-07-28")]
-            assert actual == expected
+        await t.run_async_select_cursor_context_manager(conn, queries, t.todate)
 
 
 @pytest.mark.asyncio
 async def test_select_one(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        actual = await queries.users.get_by_username(conn, username="johndoe")
-
-    expected = (2, "johndoe", "John", "Doe")
-    assert actual == expected
+        await t.run_async_select_one(conn, queries)
 
 
 @pytest.mark.asyncio
 async def test_select_value(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        actual = await queries.users.get_count(conn)
-
-    expected = 3
-    assert actual == expected
+        await t.run_async_select_value(conn, queries)
 
 
 @pytest.mark.asyncio
 async def test_insert_returning(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        blogid = await queries.blogs.publish_blog(
-            conn, userid=2, title="My first blog", content="Hello, World!", published="2018-12-04"
-        )
-
-        sql = """
-            select title
-              from blogs
-             where blogid = :blogid;"""
-        async with conn.execute(sql, {"blogid": blogid}) as cur:
-            actual = await cur.fetchone()
-            expected = ("My first blog",)
-            assert actual == expected
+        await t.run_async_insert_returning(conn, queries, "sqlite", t.todate)
 
 
 @pytest.mark.asyncio
 async def test_delete(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        # Removing the "janedoe" blog titled "Testing"
-        actual = await queries.blogs.remove_blog(conn, blogid=2)
-        assert actual is None
-
-        janes_blogs = await queries.blogs.get_user_blogs(conn, userid=3)
-        assert len(janes_blogs) == 0
+        await t.run_async_delete(conn, queries)
 
 
 @pytest.mark.asyncio
 async def test_insert_many(sqlite3_db_path, queries):
-    blogs = [
-        (2, "Blog Part 1", "content - 1", "2018-12-04"),
-        (2, "Blog Part 2", "content - 2", "2018-12-05"),
-        (2, "Blog Part 3", "content - 3", "2018-12-06"),
-    ]
-
     async with aiosqlite.connect(sqlite3_db_path) as conn:
-        actual = await queries.blogs.sqlite_bulk_publish(conn, blogs)
-        assert actual is None
-
-        johns_blogs = await queries.blogs.get_user_blogs(conn, userid=2)
-        assert johns_blogs == [
-            ("Blog Part 3", "2018-12-06"),
-            ("Blog Part 2", "2018-12-05"),
-            ("Blog Part 1", "2018-12-04"),
-        ]
+        await t.run_async_insert_many(conn, queries, t.todate)
 
 
 @pytest.mark.asyncio
 async def test_async_methods(sqlite3_db_path, queries):
     async with aiosqlite.connect(sqlite3_db_path) as conn:
         conn.row_factory = dict_factory
-        users, sorted_users = await asyncio.gather(
-            queries.users.get_all(conn), queries.users.get_all_sorted(conn)
-        )
-
-    assert users == [
-        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
-        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
-        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
-    ]
-    assert sorted_users == [
-        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
-        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
-        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
-    ]
+        await t.run_async_methods(conn, queries)
 
 
 @pytest.mark.asyncio

--- a/tests/test_asyncpg.py
+++ b/tests/test_asyncpg.py
@@ -1,50 +1,29 @@
-import asyncio
 from datetime import date
-from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import asyncpg
+
 import pytest
-
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: date
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+import run_tests as t
 
 
 @pytest.fixture()
 def queries():
-    dir_path = Path(__file__).parent / "blogdb/sql"
-    return aiosql.from_path(dir_path, "asyncpg", RECORD_CLASSES)
+    return t.queries("asyncpg")
 
 
 @pytest.mark.asyncio
 async def test_record_query(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    actual = [dict(rec) for rec in await queries.users.get_all(conn)]
+    await t.run_async_record_query(conn, queries)
     await conn.close()
-
-    assert len(actual) == 3
-    assert actual[0] == {
-        "userid": 1,
-        "username": "bobsmith",
-        "firstname": "Bob",
-        "lastname": "Smith",
-    }
 
 
 @pytest.mark.asyncio
 async def test_parameterized_query(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    actual = await queries.blogs.get_user_blogs(conn, userid=1)
+    actual = await t.run_async_parameterized_query(conn, queries, date)
     await conn.close()
-
-    expected = [("How to make a pie.", date(2018, 11, 23)), ("What I did Today", date(2017, 7, 28))]
-    assert actual == expected
 
 
 @pytest.mark.asyncio
@@ -71,89 +50,43 @@ async def test_many_replacements(pg_dsn, queries):
 @pytest.mark.asyncio
 async def test_parameterized_record_query(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    records = await queries.blogs.pg_get_blogs_published_after(conn, published=date(2018, 1, 1))
-    actual = [dict(rec) for rec in records]
+    await t.run_async_parameterized_record_query(conn, queries, "pg", date)
     await conn.close()
-
-    expected = [
-        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
-        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
-    ]
-
-    assert actual == expected
 
 
 @pytest.mark.asyncio
 async def test_record_class_query(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    actual = await queries.blogs.get_user_blogs(conn, userid=1)
-
-    expected = [
-        UserBlogSummary(title="How to make a pie.", published=date(2018, 11, 23)),
-        UserBlogSummary(title="What I did Today", published=date(2017, 7, 28)),
-    ]
-
-    assert all(isinstance(row, UserBlogSummary) for row in actual)
-    assert actual == expected
-
-    one = await queries.blogs.get_latest_user_blog(conn, userid=1)
-    assert one == UserBlogSummary(title="How to make a pie.", published=date(2018, 11, 23))
-
+    await t.run_async_record_class_query(conn, queries, date)
     await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_select_cursor_context_manager(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    async with queries.blogs.get_user_blogs_cursor(conn, userid=1) as cursor:
-        actual = [tuple(rec) async for rec in cursor]
-        expected = [
-            ("How to make a pie.", date(2018, 11, 23)),
-            ("What I did Today", date(2017, 7, 28)),
-        ]
-        assert actual == expected
+    await t.run_async_select_cursor_context_manager(conn, queries, date)
     await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_select_one(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    actual = await queries.users.get_by_username(conn, username="johndoe")
-    expected = (2, "johndoe", "John", "Doe")
-    assert actual == expected
+    await t.run_async_select_one(conn, queries)
+    await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_select_value(pg_dsn, queries):
     conn = await asyncpg.connect(pg_dsn)
-    actual = await queries.users.get_count(conn)
-    expected = 3
-    assert actual == expected
+    await t.run_async_select_value(conn, queries)
+    await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_insert_returning(pg_dsn, queries):
     async with asyncpg.create_pool(pg_dsn) as pool:
-        blogid, title = await queries.blogs.pg_publish_blog(
-            pool,
-            userid=2,
-            title="My first blog",
-            content="Hello, World!",
-            published=date(2018, 12, 4),
-        )
         async with pool.acquire() as conn:
-            record = await conn.fetchrow(
-                """\
-                select blogid,
-                       title
-                  from blogs
-                 where blogid = $1;
-                """,
-                blogid,
-            )
-            expected = tuple(record)
-
-    assert (blogid, title) == expected
+            await t.run_async_insert_returning(conn, queries, "pg", date)
 
     conn = await asyncpg.connect(pg_dsn)
     res = await queries.blogs.pg_no_publish(conn)
@@ -163,76 +96,28 @@ async def test_insert_returning(pg_dsn, queries):
 
 @pytest.mark.asyncio
 async def test_delete(pg_dsn, queries):
-    # Removing the "janedoe" blog titled "Testing"
     conn = await asyncpg.connect(pg_dsn)
-
-    actual = await queries.blogs.remove_blog(conn, blogid=2)
-    assert actual is None
-
-    janes_blogs = await queries.blogs.get_user_blogs(conn, userid=3)
-    assert len(janes_blogs) == 0
-
+    await t.run_async_delete(conn, queries)
     await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_insert_many(pg_dsn, queries):
-    blogs = [
-        {
-            "userid": 2,
-            "title": "Blog Part 1",
-            "content": "content - 1",
-            "published": date(2018, 12, 4),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 2",
-            "content": "content - 2",
-            "published": date(2018, 12, 5),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 3",
-            "content": "content - 3",
-            "published": date(2018, 12, 6),
-        },
-    ]
     conn = await asyncpg.connect(pg_dsn)
-    actual = await queries.blogs.pg_bulk_publish(conn, blogs)
-    assert actual is None
-
-    johns_blogs = await queries.blogs.get_user_blogs(conn, userid=2)
-    assert johns_blogs == [
-        ("Blog Part 3", date(2018, 12, 6)),
-        ("Blog Part 2", date(2018, 12, 5)),
-        ("Blog Part 1", date(2018, 12, 4)),
-    ]
+    await t.run_async_insert_many(conn, queries, date)
     await conn.close()
 
 
 @pytest.mark.asyncio
 async def test_async_methods(pg_dsn, queries):
     async with asyncpg.create_pool(pg_dsn) as pool:
-        users, sorted_users = await asyncio.gather(
-            queries.users.get_all(pool), queries.users.get_all_sorted(pool)
-        )
-
-    assert [dict(u) for u in users] == [
-        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
-        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
-        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
-    ]
-    assert [dict(u) for u in sorted_users] == [
-        {"userid": 1, "username": "bobsmith", "firstname": "Bob", "lastname": "Smith"},
-        {"userid": 3, "username": "janedoe", "firstname": "Jane", "lastname": "Doe"},
-        {"userid": 2, "username": "johndoe", "firstname": "John", "lastname": "Doe"},
-    ]
+        await t.run_async_methods(pool, queries)
 
 
 @pytest.mark.asyncio
 async def test_execute_script(pg_dsn, queries):
     async with asyncpg.create_pool(pg_dsn) as pool:
-        actual = await queries.comments.pg_create_comments_table(pool)
+        actual = await queries.comments.pg_create_comments_table(pool, queries)
         assert actual == "CREATE TABLE"
 
 

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -2,12 +2,12 @@ import inspect
 from pathlib import Path
 from unittest import mock
 
-import pytest
 import aiosql
-
 from aiosql.exceptions import SQLParseException
 from aiosql.queries import Queries
 from aiosql.query_loader import QueryLoader
+
+import pytest
 
 
 @pytest.fixture
@@ -94,12 +94,33 @@ def test_loading_query_signature_with_duplicate_parameter():
     )
 
 
-def test_no_adapter():
+def test_adapters():
     try:
         aiosql.aiosql._make_driver_adapter("no-such-driver-adapter")
         assert False, "must raise an exception"  # pragma: no cover
     except ValueError as e:
         assert "unregistered driver_adapter" in str(e)
+
+    class PyFormatConnector:
+        paramstyle = "pyformat"
+
+    a = aiosql.aiosql._make_driver_adapter(PyFormatConnector)
+    assert type(a) == aiosql.adapters.PyFormatAdapter
+
+    class NamedConnector:
+        paramstyle = "named"
+
+    a = aiosql.aiosql._make_driver_adapter(NamedConnector)
+    assert type(a) == aiosql.adapters.GenericAdapter
+
+    class NoSuchConnector:
+        paramstyle = "no-such-style"
+
+    try:
+        aiosql.aiosql._make_driver_adapter(NoSuchConnector)
+        assert False, "must raise an exception"  # pragma: no cover
+    except ValueError as e:
+        assert "Unexpected driver_adapter" in str(e)
 
 
 def test_no_such_path():

--- a/tests/test_mysqldb.py
+++ b/tests/test_mysqldb.py
@@ -1,0 +1,85 @@
+from datetime import date
+
+import aiosql
+import MySQLdb as ms
+
+import pytest
+import run_tests as t
+
+pytestmark = pytest.mark.skipif(not t.has_exec("mysqld"), reason="no mysqld")
+
+
+@pytest.fixture()
+def queries():
+    return t.queries("mysqldb")
+
+
+# is pytest-mysql running as expected?
+def test_proc(mysql_proc):
+    assert mysql_proc.running()
+
+
+def test_query(mysql):
+    t.run_something(mysql)
+
+
+def test_my_dsn(my_dsn):
+    assert "user" in my_dsn and "host" in my_dsn and "port" in my_dsn
+
+
+def test_my_db(my_db):
+    t.run_something(my_db)
+
+
+# FIXME
+@pytest.mark.skip("cannot connect obscure issue")
+def test_record_query(my_dsn, queries):  # pragma: no cover
+    with ms.connect(**my_dsn) as conn:
+        t.run_record_query(conn, queries)
+
+
+def test_parameterized_query(my_db, queries):
+    t.run_parameterized_query(my_db, queries)
+    my_db.commit()  # or fails on teardown
+
+
+@pytest.mark.skip("cannot connect obscure issue")
+def test_parameterized_record_query(my_dsn, queries):  # pragma: no cover
+    with ms.connect(**my_dsn) as conn:
+        t.run_parameterized_record_query(conn, queries, "my", date)
+
+
+def test_record_class_query(my_db, queries):
+    t.run_record_class_query(my_db, queries, date)
+    my_db.commit()  # or fail on teardown
+
+
+def test_select_cursor_context_manager(my_db, queries):
+    t.run_select_cursor_context_manager(my_db, queries, date)
+    my_db.commit()  # or fail on teardown
+
+
+def test_select_one(my_db, queries):
+    t.run_select_one(my_db, queries)
+    my_db.commit()  # or fail on teardown
+
+
+def test_select_value(my_db, queries):
+    t.run_select_value(my_db, queries)
+    my_db.commit()  # or fail on teardown
+
+
+@pytest.mark.skip("mysql does not support RETURNING, but mariadb yes")
+def test_insert_returning(my_db, queries):  # pragma: no cover
+    t.run_insert_returning(my_db, queries, "my", date)
+    my_db.commit()  # or fail on teardown
+
+
+def test_delete(my_db, queries):
+    t.run_delete(my_db, queries)
+    my_db.commit()  # or fails on teardown
+
+
+def test_insert_many(my_db, queries):
+    t.run_insert_many(my_db, queries, date)
+    my_db.commit()

--- a/tests/test_psycopg.py
+++ b/tests/test_psycopg.py
@@ -1,99 +1,50 @@
 from datetime import date
-from pathlib import Path
-from typing import NamedTuple
-import re
 
 import aiosql
 import psycopg
 from psycopg.rows import dict_row
+
 import pytest
-
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: date
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+import run_tests as t
 
 
 @pytest.fixture()
 def queries():
-    dir_path = Path(__file__).parent / "blogdb" / "sql"
-    return aiosql.from_path(dir_path, "psycopg", RECORD_CLASSES)
-
-
-def get_parameters(pg_conn):
-    if hasattr(pg_conn, "get_dsn_parameters"):  # pragma: no cover
-        dsn = pg_conn.get_dsn_parameters()
-        del dsn["tty"]
-    else:
-        dsn = pg_conn.info.get_parameters()
-    return dsn
+    return t.queries("psycopg")
 
 
 def test_version():
-    assert re.match(r"^3\.", psycopg.__version__)
+    assert psycopg.__version__.startswith("3.")
 
 
-def test_record_query(pg_conn, queries):
-    dsn = get_parameters(pg_conn)
-    with psycopg.connect(**dsn, row_factory=dict_row) as conn:
-        actual = queries.users.get_all(conn)
-
-    assert len(actual) == 3
-    assert actual[0] == {
-        "userid": 1,
-        "username": "bobsmith",
-        "firstname": "Bob",
-        "lastname": "Smith",
-    }
+def test_record_query(pg_params, queries):
+    with psycopg.connect(**pg_params, row_factory=dict_row) as conn:
+        t.run_record_query(conn, queries)
 
 
 def test_parameterized_query(pg_conn, queries):
-    actual = queries.users.get_by_lastname(pg_conn, lastname="Doe")
-    expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
-    assert actual == expected
+    t.run_parameterized_query(pg_conn, queries)
 
 
-def test_parameterized_record_query(pg_conn, queries):
-    dsn = get_parameters(pg_conn)
-    with psycopg.connect(**dsn, row_factory=dict_row) as conn:
-        actual = queries.blogs.pg_get_blogs_published_after(conn, published=date(2018, 1, 1))
-
-    expected = [
-        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
-        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
-    ]
-
-    assert actual == expected
+def test_parameterized_record_query(pg_params, queries):
+    with psycopg.connect(**pg_params, row_factory=dict_row) as conn:
+        t.run_parameterized_record_query(conn, queries, "pg", date)
 
 
 def test_record_class_query(pg_conn, queries):
-    actual = queries.blogs.get_user_blogs(pg_conn, userid=1)
-    expected = [
-        UserBlogSummary(title="How to make a pie.", published=date(2018, 11, 23)),
-        UserBlogSummary(title="What I did Today", published=date(2017, 7, 28)),
-    ]
-
-    assert all(isinstance(row, UserBlogSummary) for row in actual)
-    assert actual == expected
+    t.run_record_class_query(pg_conn, queries, date)
 
 
 def test_select_cursor_context_manager(pg_conn, queries):
-    with queries.blogs.get_user_blogs_cursor(pg_conn, userid=1) as cursor:
-        actual = cursor.fetchall()
-        expected = [
-            ("How to make a pie.", date(2018, 11, 23)),
-            ("What I did Today", date(2017, 7, 28)),
-        ]
-        assert actual == expected
+    t.run_select_cursor_context_manager(pg_conn, queries, date)
 
 
 def test_select_one(pg_conn, queries):
-    actual = queries.users.get_by_username(pg_conn, username="johndoe")
-    expected = (2, "johndoe", "John", "Doe")
-    assert actual == expected
+    t.run_select_one(pg_conn, queries)
+
+
+def test_select_value(pg_conn, queries):
+    t.run_select_value(pg_conn, queries)
 
 
 def test_modulo(pg_conn, queries):
@@ -103,67 +54,13 @@ def test_modulo(pg_conn, queries):
 
 
 def test_insert_returning(pg_conn, queries):
-    with pg_conn:
-        blogid, title = queries.blogs.pg_publish_blog(
-            pg_conn,
-            userid=2,
-            title="My first blog",
-            content="Hello, World!",
-            published=date(2018, 12, 4),
-        )
-        with pg_conn.cursor() as cur:
-            cur.execute(
-                """\
-                select blogid,
-                       title
-                  from blogs
-                 where blogid = %s;
-                """,
-                (blogid,),
-            )
-            expected = cur.fetchone()
-
-    assert (blogid, title) == expected
+    t.run_insert_returning(pg_conn, queries, "pg", date)
 
 
 def test_delete(pg_conn, queries):
-    # Removing the "janedoe" blog titled "Testing"
-    actual = queries.blogs.remove_blog(pg_conn, blogid=2)
-    assert actual == 1
-
-    janes_blogs = queries.blogs.get_user_blogs(pg_conn, userid=3)
-    assert len(janes_blogs) == 0
+    t.run_delete(pg_conn, queries)
 
 
 def test_insert_many(pg_conn, queries):
-    blogs = [
-        {
-            "userid": 2,
-            "title": "Blog Part 1",
-            "content": "content - 1",
-            "published": date(2018, 12, 4),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 2",
-            "content": "content - 2",
-            "published": date(2018, 12, 5),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 3",
-            "content": "content - 3",
-            "published": date(2018, 12, 6),
-        },
-    ]
-
     with pg_conn:
-        actual = queries.blogs.pg_bulk_publish(pg_conn, blogs)
-        assert actual == 3
-
-        johns_blogs = queries.blogs.get_user_blogs(pg_conn, userid=2)
-        assert johns_blogs == [
-            ("Blog Part 3", date(2018, 12, 6)),
-            ("Blog Part 2", date(2018, 12, 5)),
-            ("Blog Part 1", date(2018, 12, 4)),
-        ]
+        t.run_insert_many(pg_conn, queries, date)

--- a/tests/test_psycopg2.py
+++ b/tests/test_psycopg2.py
@@ -1,19 +1,11 @@
 from datetime import date
-from pathlib import Path
-from typing import NamedTuple
 
 import aiosql
 import psycopg2
 import psycopg2.extras
+
 import pytest
-
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: date
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+import run_tests as t
 
 
 def test_version():
@@ -22,75 +14,37 @@ def test_version():
 
 @pytest.fixture()
 def queries():
-    dir_path = Path(__file__).parent / "blogdb" / "sql"
-    return aiosql.from_path(dir_path, "psycopg2", RECORD_CLASSES)
+    return t.queries("psycopg2")
 
 
 def test_record_query(pg_dsn, queries):
     with psycopg2.connect(dsn=pg_dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
-        actual = queries.users.get_all(conn)
-
-    assert len(actual) == 3
-    assert actual[0] == {
-        "userid": 1,
-        "username": "bobsmith",
-        "firstname": "Bob",
-        "lastname": "Smith",
-    }
+        t.run_record_query(conn, queries)
 
 
 def test_parameterized_query(pg_conn, queries):
-    actual = queries.users.get_by_lastname(pg_conn, lastname="Doe")
-    expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
-    assert actual == expected
+    t.run_parameterized_query(pg_conn, queries)
 
 
 def test_parameterized_record_query(pg_dsn, queries):
     with psycopg2.connect(dsn=pg_dsn, cursor_factory=psycopg2.extras.RealDictCursor) as conn:
-        actual = queries.blogs.pg_get_blogs_published_after(conn, published=date(2018, 1, 1))
-
-    expected = [
-        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
-        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
-    ]
-
-    assert actual == expected
+        t.run_parameterized_record_query(conn, queries, "pg", date)
 
 
 def test_record_class_query(pg_conn, queries):
-    actual = queries.blogs.get_user_blogs(pg_conn, userid=1)
-    expected = [
-        UserBlogSummary(title="How to make a pie.", published=date(2018, 11, 23)),
-        UserBlogSummary(title="What I did Today", published=date(2017, 7, 28)),
-    ]
-
-    assert all(isinstance(row, UserBlogSummary) for row in actual)
-    assert actual == expected
-
-    one = queries.blogs.get_latest_user_blog(pg_conn, userid=1)
-    assert one == UserBlogSummary(title="How to make a pie.", published=date(2018, 11, 23))
+    t.run_record_class_query(pg_conn, queries, date)
 
 
 def test_select_cursor_context_manager(pg_conn, queries):
-    with queries.blogs.get_user_blogs_cursor(pg_conn, userid=1) as cursor:
-        actual = cursor.fetchall()
-        expected = [
-            ("How to make a pie.", date(2018, 11, 23)),
-            ("What I did Today", date(2017, 7, 28)),
-        ]
-        assert actual == expected
+    t.run_select_cursor_context_manager(pg_conn, queries, date)
 
 
 def test_select_one(pg_conn, queries):
-    actual = queries.users.get_by_username(pg_conn, username="johndoe")
-    expected = (2, "johndoe", "John", "Doe")
-    assert actual == expected
+    t.run_select_one(pg_conn, queries)
 
 
 def test_select_value(pg_conn, queries):
-    actual = queries.users.get_count(pg_conn)
-    expected = 3
-    assert actual == expected
+    t.run_select_value(pg_conn, queries)
 
 
 def test_modulo(pg_conn, queries):
@@ -100,73 +54,16 @@ def test_modulo(pg_conn, queries):
 
 
 def test_insert_returning(pg_conn, queries):
-    with pg_conn:
-        blogid, title = queries.blogs.pg_publish_blog(
-            pg_conn,
-            userid=2,
-            title="My first blog",
-            content="Hello, World!",
-            published=date(2018, 12, 4),
-        )
-        with pg_conn.cursor() as cur:
-            cur.execute(
-                """\
-                select blogid,
-                       title
-                  from blogs
-                 where blogid = %s;
-                """,
-                (blogid,),
-            )
-            expected = cur.fetchone()
-        # test empty result
-        res = queries.blogs.pg_no_publish(pg_conn)
-        assert res is None
-
-    assert (blogid, title) == expected
+    t.run_insert_returning(pg_conn, queries, "pg", date)
 
 
 def test_delete(pg_conn, queries):
-    # Removing the "janedoe" blog titled "Testing"
-    actual = queries.blogs.remove_blog(pg_conn, blogid=2)
-    assert actual == 1
-
-    janes_blogs = queries.blogs.get_user_blogs(pg_conn, userid=3)
-    assert len(janes_blogs) == 0
+    t.run_delete(pg_conn, queries)
 
 
 def test_insert_many(pg_conn, queries):
-    blogs = [
-        {
-            "userid": 2,
-            "title": "Blog Part 1",
-            "content": "content - 1",
-            "published": date(2018, 12, 4),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 2",
-            "content": "content - 2",
-            "published": date(2018, 12, 5),
-        },
-        {
-            "userid": 2,
-            "title": "Blog Part 3",
-            "content": "content - 3",
-            "published": date(2018, 12, 6),
-        },
-    ]
-
     with pg_conn:
-        actual = queries.blogs.pg_bulk_publish(pg_conn, blogs)
-        assert actual == 3
-
-        johns_blogs = queries.blogs.get_user_blogs(pg_conn, userid=2)
-        assert johns_blogs == [
-            ("Blog Part 3", date(2018, 12, 6)),
-            ("Blog Part 2", date(2018, 12, 5)),
-            ("Blog Part 1", date(2018, 12, 4)),
-        ]
+        t.run_insert_many(pg_conn, queries, date)
 
 
 def test_execute_script(pg_conn, queries):

--- a/tests/test_sqlite3.py
+++ b/tests/test_sqlite3.py
@@ -1,16 +1,7 @@
-from pathlib import Path
-from typing import NamedTuple
-
 import aiosql
+
 import pytest
-
-
-class UserBlogSummary(NamedTuple):
-    title: str
-    published: str
-
-
-RECORD_CLASSES = {"UserBlogSummary": UserBlogSummary}
+import run_tests as t
 
 
 def dict_factory(cursor, row):
@@ -22,72 +13,37 @@ def dict_factory(cursor, row):
 
 @pytest.fixture()
 def queries():
-    p = Path(__file__).parent / "blogdb" / "sql"
-    return aiosql.from_path(p, "sqlite3", RECORD_CLASSES)
+    return t.queries("sqlite3")
 
 
 def test_record_query(sqlite3_conn, queries):
     sqlite3_conn.row_factory = dict_factory
-    actual = queries.users.get_all(sqlite3_conn)
-
-    assert len(actual) == 3
-    assert actual[0] == {
-        "userid": 1,
-        "username": "bobsmith",
-        "firstname": "Bob",
-        "lastname": "Smith",
-    }
+    t.run_record_query(sqlite3_conn, queries)
 
 
 def test_parameterized_query(sqlite3_conn, queries):
-    actual = queries.users.get_by_lastname(sqlite3_conn, lastname="Doe")
-    expected = [(3, "janedoe", "Jane", "Doe"), (2, "johndoe", "John", "Doe")]
-    assert actual == expected
+    t.run_parameterized_query(sqlite3_conn, queries)
 
 
 def test_parameterized_record_query(sqlite3_conn, queries):
     sqlite3_conn.row_factory = dict_factory
-    actual = queries.blogs.sqlite_get_blogs_published_after(sqlite3_conn, published="2018-01-01")
-
-    expected = [
-        {"title": "How to make a pie.", "username": "bobsmith", "published": "2018-11-23 00:00"},
-        {"title": "Testing", "username": "janedoe", "published": "2018-01-01 00:00"},
-    ]
-
-    assert actual == expected
+    t.run_parameterized_record_query(sqlite3_conn, queries, "sqlite", t.todate)
 
 
 def test_record_class_query(sqlite3_conn, queries):
-    actual = queries.blogs.get_user_blogs(sqlite3_conn, userid=1)
-    expected = [
-        UserBlogSummary(title="How to make a pie.", published="2018-11-23"),
-        UserBlogSummary(title="What I did Today", published="2017-07-28"),
-    ]
-
-    assert all(isinstance(row, UserBlogSummary) for row in actual)
-    assert actual == expected
-
-    one = queries.blogs.get_latest_user_blog(sqlite3_conn, userid=1)
-    assert one == UserBlogSummary(title="How to make a pie.", published="2018-11-23")
+    t.run_record_class_query(sqlite3_conn, queries, t.todate)
 
 
 def test_select_cursor_context_manager(sqlite3_conn, queries):
-    with queries.blogs.get_user_blogs_cursor(sqlite3_conn, userid=1) as cursor:
-        actual = cursor.fetchall()
-        expected = [("How to make a pie.", "2018-11-23"), ("What I did Today", "2017-07-28")]
-        assert actual == expected
+    t.run_select_cursor_context_manager(sqlite3_conn, queries, t.todate)
 
 
 def test_select_one(sqlite3_conn, queries):
-    actual = queries.users.get_by_username(sqlite3_conn, username="johndoe")
-    expected = (2, "johndoe", "John", "Doe")
-    assert actual == expected
+    t.run_select_one(sqlite3_conn, queries)
 
 
 def test_select_value(sqlite3_conn, queries):
-    actual = queries.users.get_count(sqlite3_conn)
-    expected = 3
-    assert actual == expected
+    t.run_select_value(sqlite3_conn, queries)
 
 
 def test_modulo(sqlite3_conn, queries):
@@ -97,56 +53,16 @@ def test_modulo(sqlite3_conn, queries):
 
 
 def test_insert_returning(sqlite3_conn, queries):
-    with sqlite3_conn:
-        blogid = queries.blogs.publish_blog(
-            sqlite3_conn,
-            userid=2,
-            title="My first blog",
-            content="Hello, World!",
-            published="2018-12-04",
-        )
-    cur = sqlite3_conn.cursor()
-    cur.execute(
-        """\
-        select title
-          from blogs
-         where blogid = ?;
-    """,
-        (blogid,),
-    )
-    actual = cur.fetchone()
-    cur.close()
-    expected = ("My first blog",)
-
-    assert actual == expected
+    t.run_insert_returning(sqlite3_conn, queries, "sqlite", t.todate)
 
 
 def test_delete(sqlite3_conn, queries):
-    # Removing the "janedoe" blog titled "Testing"
-    actual = queries.blogs.remove_blog(sqlite3_conn, blogid=2)
-    assert actual == 1
-
-    janes_blogs = queries.blogs.get_user_blogs(sqlite3_conn, userid=3)
-    assert len(janes_blogs) == 0
+    t.run_delete(sqlite3_conn, queries)
 
 
 def test_insert_many(sqlite3_conn, queries):
-    blogs = [
-        (2, "Blog Part 1", "content - 1", "2018-12-04"),
-        (2, "Blog Part 2", "content - 2", "2018-12-05"),
-        (2, "Blog Part 3", "content - 3", "2018-12-06"),
-    ]
-
     with sqlite3_conn:
-        actual = queries.blogs.sqlite_bulk_publish(sqlite3_conn, blogs)
-        assert actual == 3
-
-        johns_blogs = queries.blogs.get_user_blogs(sqlite3_conn, userid=2)
-        assert johns_blogs == [
-            ("Blog Part 3", "2018-12-06"),
-            ("Blog Part 2", "2018-12-05"),
-            ("Blog Part 1", "2018-12-04"),
-        ]
+        t.run_insert_many(sqlite3_conn, queries, t.todate)
 
 
 def test_execute_script(sqlite3_conn, queries):


### PR DESCRIPTION
This patch adds support for mysql through `mysqlclient` and `pymysql` drivers.

It is on top of the adaptater restructuring for psycopg 2/3 and pytest-postgresql 4 as it takes advantage of it.
The AioSQL features more or less worked out of the box, but `pytest-mysql` took quite a long time to work.

There is no documentation update, shame on me.