### PR TITLE
Fix link

### DIFF
--- a/docs/source/advanced-topics.rst
+++ b/docs/source/advanced-topics.rst
@@ -144,7 +144,7 @@ Below are two example of a program which can print ``"{greeting}, {world_name}!"
       from worlds
      where world_name = :world_name;
 
-Notice there is a usage of the ```^`` Select One Query Operator <./defining-sql-queries.md#select-one>`__. Adding this to the SQL comment ``--name: get-world-by-name^`` indicates to aiosql that ``queries.get_world_by_name()`` will return a single row back.
+Notice there is a usage of the ``^`` Select One Query Operator <./defining-sql-queries.md#select-one>`__. Adding this to the SQL comment ``--name: get-world-by-name^`` indicates to aiosql that ``queries.get_world_by_name()`` will return a single row back.
 
 Sync with sqlite3
 ~~~~~~~~~~~~~~~~~

--- a/docs/source/advanced-topics.rst
+++ b/docs/source/advanced-topics.rst
@@ -144,7 +144,7 @@ Below are two example of a program which can print ``"{greeting}, {world_name}!"
       from worlds
      where world_name = :world_name;
 
-Notice there is a usage of the ``^`` Select One Query Operator <./defining-sql-queries.md#select-one>`__. Adding this to the SQL comment ``--name: get-world-by-name^`` indicates to aiosql that ``queries.get_world_by_name()`` will return a single row back.
+Notice there is a usage of the ``^`` `Select One Query Operator <./defining-sql-queries.rst#select-one>`__. Adding this to the SQL comment ``--name: get-world-by-name^`` indicates to aiosql that ``queries.get_world_by_name()`` will return a single row back.
 
 Sync with sqlite3
 ~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This change tweaks the reST markup so that both the link works (fixing the extension which is .rst not .md) and the backquotes around the "^" are not confused with the backquotes for the link.