### PR TITLE
Fix typo and warning

### DIFF
--- a/aiosql/adapters/asyncpg.py
+++ b/aiosql/adapters/asyncpg.py
@@ -44,18 +44,22 @@ class AsyncPGAdapter:
                 replacement = f"${len(self.var_sorted[query_name])+1}"
                 self.var_sorted[query_name].append(var_name)
 
+            # Determine the offset of the start and end of the original
+            # variable that we are replacing, taking into account an adjustment
+            # factor based on previous replacements (see the note below).
             start = match.start() + len(gd["lead"]) + adj
             end = match.end() - len(gd["trail"]) + adj
 
             sql = sql[:start] + replacement + sql[end:]
 
-            replacement_len = len(replacement)
-            # the lead ":" char is the reason for the +1
-            var_len = len(var_name) + 1
-            if replacement_len < var_len:
-                adj = adj + replacement_len - var_len
-            else:
-                adj = adj + var_len - replacement_len
+            # If the replacement and original variable were different lengths,
+            # then the offsets of subsequent matches will be wrong by the
+            # difference.  Calculate an adjustment to apply to reconcile those
+            # offsets with the modified string.
+            #
+            # The "- 1" is to account for the leading ":" character in the
+            # original string.
+            adj += len(replacement) - len(var_name) - 1
 
         return sql
 

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -50,7 +50,7 @@ The requirements file format is compatible with ``pip`` directly. Simply, ``pip 
 
 .. code:: sh
 
-    pip-sync requirments.txt dev-requirements.txt
+    pip-sync requirements.txt dev-requirements.txt
 
 4. Run tests
 

--- a/tests/test_patterns.py
+++ b/tests/test_patterns.py
@@ -2,7 +2,7 @@ from aiosql.patterns import var_pattern
 
 
 def test_var_pattern_is_quote_aware():
-    sql = """
+    sql = r"""
           select foo_id,
                  bar_id,
                  to_char(created_at, 'YYYY-MM-DD"T"HH24:MI:SSOF')
@@ -40,7 +40,7 @@ def test_var_pattern_does_not_require_semicolon_trail():
     """Make sure keywords ending queries are recognized even without
     semi-colons.
     """
-    sql = """
+    sql = r"""
         select a,
                b,
                c
@@ -56,7 +56,7 @@ def test_var_pattern_does_not_require_semicolon_trail():
 
 def test_var_pattern_handles_empty_sql_string_literals():
     """Make sure SQL '' are treated correctly and don't cause a substitution to be skipped."""
-    sql = """
+    sql = r"""
         select blah
           from foo
          where lower(regexp_replace(blah,'\W','','g')) = lower(regexp_replace(:blah,'\W','','g'));"""


### PR DESCRIPTION
This PR fixes two small problems.

The first is that there is a typo in the build instructions that caused them not to work if copy-pasted.

The second is a warning about a string that should have been marked as "raw".  Here is the warning:

<img width="665" alt="Screen Shot 2022-01-21 at 11 39 58 AM" src="https://user-images.githubusercontent.com/9391/150575467-907f6067-826f-4df7-a592-5e00e41ab8fd.png">

