### PR TITLE
Fix bug in variable replacement in asyncpg adapter

### DIFF
--- a/aiosql/adapters/asyncpg.py
+++ b/aiosql/adapters/asyncpg.py
@@ -44,18 +44,22 @@ class AsyncPGAdapter:
                 replacement = f"${len(self.var_sorted[query_name])+1}"
                 self.var_sorted[query_name].append(var_name)
 
+            # Determine the offset of the start and end of the original
+            # variable that we are replacing, taking into account an adjustment
+            # factor based on previous replacements (see the note below).
             start = match.start() + len(gd["lead"]) + adj
             end = match.end() - len(gd["trail"]) + adj
 
             sql = sql[:start] + replacement + sql[end:]
 
-            replacement_len = len(replacement)
-            # the lead ":" char is the reason for the +1
-            var_len = len(var_name) + 1
-            if replacement_len < var_len:
-                adj = adj + replacement_len - var_len
-            else:
-                adj = adj + var_len - replacement_len
+            # If the replacement and original variable were different lengths,
+            # then the offsets of subsequent matches will be wrong by the
+            # difference.  Calculate an adjustment to apply to reconcile those
+            # offsets with the modified string.
+            #
+            # The "- 1" is to account for the leading ":" character in the
+            # original string.
+            adj += len(replacement) - len(var_name) - 1
 
         return sql
 

--- a/tests/test_asyncpg.py
+++ b/tests/test_asyncpg.py
@@ -63,10 +63,8 @@ async def test_many_replacements(pg_dsn, queries):
         -- name: test<!
         INSERT INTO table VALUES (:a, :b, :c, :d, :e, :f, :g, :h, :i, :j, :k);
     """
-    actual = aiosql.from_str(sql, 'asyncpg').test.sql
-    expected = (
-        'INSERT INTO table '
-        'VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);')
+    actual = aiosql.from_str(sql, "asyncpg").test.sql
+    expected = "INSERT INTO table " "VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11);"
     assert actual == expected
 
 


### PR DESCRIPTION
Issue #90 noted a bug in the way variables are replaced in the asyncpg adapter.  This branch adds a test for that bug and a fix.

Here's how the test failed before the fix was added:

<img width="856" alt="Screen Shot 2022-01-21 at 1 56 03 PM" src="https://user-images.githubusercontent.com/9391/150593492-5a04b4a6-8214-4e8c-86b6-fb66ebbb734a.png">
