### PR TITLE
asyncpg adapter changes to support #84

### DIFF
--- a/aiosql/adapters/asyncpg.py
+++ b/aiosql/adapters/asyncpg.py
@@ -40,7 +40,7 @@ class AsyncPGAdapter:
             if var_name in self.var_sorted[query_name]:
                 replacement = f"${self.var_sorted[query_name].index(var_name) + 1}"
             else:
-                replacement = f"${len(self.var_sorted[query_name]) +1 }"
+                replacement = f"${len(self.var_sorted[query_name]) + 1}"
                 self.var_sorted[query_name].append(var_name)
 
             start = match.start() + len(gd["lead"]) + adj

--- a/aiosql/adapters/asyncpg.py
+++ b/aiosql/adapters/asyncpg.py
@@ -28,7 +28,6 @@ class AsyncPGAdapter:
         self.var_sorted = defaultdict(list)
 
     def process_sql(self, query_name, _op_type, sql):
-        count = 0
         adj = 0
 
         for match in var_pattern.finditer(sql):
@@ -39,9 +38,9 @@ class AsyncPGAdapter:
 
             var_name = gd["var_name"]
             if var_name in self.var_sorted[query_name]:
-                replacement = f"${self.var_sorted.index(query_name)+1}"
+                replacement = f"${self.var_sorted[query_name].index(var_name) + 1}"
             else:
-                replacement = f"${len(self.var_sorted[query_name])+1}"
+                replacement = f"${len(self.var_sorted[query_name]) +1 }"
                 self.var_sorted[query_name].append(var_name)
 
             start = match.start() + len(gd["lead"]) + adj


### PR DESCRIPTION
These are changes required to support the PR #84:
The defaultdict on line 41 was chained with `.index()` method that does not exist, and I inferred that it's really just a lookup for the replacement number placeholder in the sql that this for look has already found and cached there in `self.var_sorted`

Additionally, there was a variable `count` on original line 31 that was unused so I removed it