### PR TITLE
Do not require typing-extensions for Python ≥ 3.8

### DIFF
--- a/aiosql/types.py
+++ b/aiosql/types.py
@@ -12,7 +12,10 @@ from typing import (
     Union,
 )
 
-from typing_extensions import Protocol
+try:
+    from typing import Protocol
+except ImportError:
+    from typing_extensions import Protocol  # type: ignore
 
 
 class SQLOperationType(Enum):

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     contextlib2 >=21.6.0
-    typing-extensions >=4.0.0,<5
+    typing-extensions >=4.0.0,<5; python_version < "3.8"
 include_package_data = true
 
 [options.package_data]


### PR DESCRIPTION
Protocol is now part of standard library, see:

- https://docs.python.org/3/library/typing.html#typing.Protocol
- https://www.python.org/dev/peps/pep-0544/

And typing-extensions uses Protocol from typing with Python ≥ 3.8:

https://github.com/python/typing/blob/4.0.1/typing_extensions/src/typing_extensions.py#L510-L512