### PR TITLE
v4.0

### DIFF
--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -99,16 +99,16 @@ def _make_ctx_mgr(fn: QueryFn) -> QueryFn:
 
 
 def _create_methods(query_datum: QueryDatum, is_aio: bool) -> List[Tuple[str, QueryFn]]:
+    """Internal function to feed add_queries."""
     fn = _make_sync_fn(query_datum)
     if is_aio:
         fn = _make_async_fn(fn)
 
     ctx_mgr = _make_ctx_mgr(fn)
 
-    # TODO: 4.0.0 release
+    # TODO in a later release?
     # The return can and should be simplified to List[QueryFn]
-    # i.e.
-    # return [fn, ctx_mgr] and [fn]
+    # i.e. "return [fn, ctx_mgr] and [fn]"
     if query_datum.operation_type == SQLOperationType.SELECT:
         return [(fn.__name__, fn), (ctx_mgr.__name__, ctx_mgr)]
     else:
@@ -158,9 +158,9 @@ class Queries:
     def add_queries(self, queries: List[Tuple[str, QueryFn]]):
         """Add query methods to `Queries` instance."""
         for query_name, fn in queries:
-            # TODO: Could be query_name = fn.__name__.rpartition(".")[2]
+            # TODO Could be query_name = fn.__name__.rpartition(".")[2]
             # if the interface here were changed to just queries being
-            # a List[QueryFn]
+            # a List[QueryFn] (see _create_methods)
             query_name = query_name.rpartition(".")[2]
             self.add_query(query_name, MethodType(fn, self))
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ author = "William Vaughn <vaughnwilld@gmail.com>"
 github_doc_root = "https://github.com/nackjicholson/aiosql/tree/master/docs/source/"
 
 # The full version, including alpha/beta/rc tags
-release = "3.4.1"
+release = "4.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = aiosql
-version = 3.4.1
+version = 4.0
 author = William Vaughn
 author_email = vaughnwilld@gmail.com
 description = Simple SQL in Python

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,6 +1,7 @@
 import inspect
 from pathlib import Path
 from unittest import mock
+import re
 
 import aiosql
 from aiosql.exceptions import SQLParseException
@@ -24,6 +25,10 @@ def sql_file(sql_dir):
 def sql(sql_file):
     with open(sql_file) as f:
         return f.read()
+
+
+def test_version():
+    assert re.match(r"\d+\.\d+$", aiosql.__version__)
 
 
 def test_frompath_queries_cls(sql_dir):


### PR DESCRIPTION
Next version candidate.

Although the interface does not change, because there is a lot of refactoring and driver support added, changes the major version. Also, the project ambition does not seem to warrant a 3-level version numbering, so use 2.