### PR TITLE
Add query filename info so that goto-definition works in editors

### DIFF
--- a/aiosql/queries.py
+++ b/aiosql/queries.py
@@ -22,11 +22,11 @@ def _query_fn(
     signature: Optional[inspect.Signature],
     fname: Optional[Path] = None
 ) -> QueryFn:
+    if fname:
+        fn.__code__ = fn.__code__.replace(co_filename=str(fname), co_firstlineno=1)
     qfn = cast(QueryFn, fn)
     qfn.__name__ = name
     qfn.__doc__ = doc
-    if fname:
-        qfn.__code__ = qfn.__code__.replace(co_filename=str(fname), co_firstlineno=1)
     qfn.__signature__ = signature
     qfn.sql = sql
     qfn.operation = operation

--- a/aiosql/types.py
+++ b/aiosql/types.py
@@ -1,5 +1,6 @@
 import inspect
 from enum import Enum
+from pathlib import Path
 from typing import (
     Any,
     AsyncContextManager,
@@ -38,6 +39,7 @@ class QueryDatum(NamedTuple):
     sql: str
     record_class: Any = None
     signature: Optional[inspect.Signature] = None
+    fname: Optional[Path] = None
 
 
 class QueryFn(Protocol):


### PR DESCRIPTION
Great project. The only thing that was missing for me currently was goto-definition.

Editors can use `fn.__code__.co_filename` to implement goto-definition.

With this change, goto-definition for a query function will go to that function's SQL file, in case the function was created with `aiosql.from_path`.
