### PR TITLE
Add support for multiline comments.

### DIFF
--- a/aiosql/query_loader.py
+++ b/aiosql/query_loader.py
@@ -19,7 +19,7 @@ _NAME_OP = re.compile(r"^(\w+)(|\^|\$|!|<!|\*!|#)$")
 _BAD_PREFIX = re.compile(r"^\d")
 
 # get SQL comment contents
-_SQL_COMMENT = re.compile(r"\s*--\s*(.*)$")
+_SQL_COMMENT = re.compile(r"\s*--\s*(.*)|/\*\s*([^\*]*)\s*")
 
 # map operation suffixes to their type
 _OP_TYPES = {
@@ -72,13 +72,11 @@ class QueryLoader:
 
     def _get_sql_doc(self, lines: Sequence[str]) -> Tuple[str, str]:
         doc, sql = "", ""
+        for doc_match in _SQL_COMMENT.finditer("\n".join(lines)):
+            doc += next(group for group in doc_match.groups() if group) + "\n"
         for line in lines:
-            doc_match = _SQL_COMMENT.match(line)
-            if doc_match:
-                doc += doc_match.group(1) + "\n"
-            else:
+            if not _SQL_COMMENT.match(line):
                 sql += line + "\n"
-
         return sql.strip(), doc.rstrip()
 
     def _build_signature(self, sql: str) -> inspect.Signature:

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -184,3 +184,22 @@ def test_misc(sql_file):
         assert False, "must raise en exception"  # pragma: no cover
     except ValueError as e:
         assert "must be a directory" in str(e)
+
+
+@pytest.mark.parametrize(
+    "comment,expected",
+    [
+        ("--comment", "comment"),
+        ("--comment comment", "comment comment"),
+        ("--comment\n--comment", "comment\ncomment"),
+        ("-- comment ", "comment"),
+        ("/*comment*/", "comment"),
+        ("/* comment */", "comment"),
+        ("/* comment\n */", "comment"),
+        ("/* comment \n comment */", "comment\ncomment"),
+        ("/* comment \n comment\n comment*/", "comment\ncomment\ncomment"),
+    ]
+)
+def test_comments(comment, expected):
+    queries = aiosql.from_str(f"--name: one$\n{comment}\nSELECT 1;", "sqlite3")
+    assert queries.one.__doc__ == expected


### PR DESCRIPTION
I Changed the _SQL_COMMENT regex in `aiosql/query_loader.py` to work on single and multiline `/* */` style comments. I created a new test for it in `tests/test_loading.py` to show that it didn't break the previous behavior.