### PR TITLE
Add aiosql.adapters module to built packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dist = [
 aiosql = [ "py.typed" ]
 
 [tool.setuptools.packages.find]
-include = [ "aiosql" ]
+include = [ "aiosql", "aiosql.adapters" ]
 exclude = [ "tests" ]
 
 [project.urls]


### PR DESCRIPTION
When the package is built from git, it works because setuptools-scm registers a [`setuptools.file_finders` entry point][1], which provides setuptools with a list of all files managed by git, and setuptools [adds them][2] to built packages (sdist and wheel).

However, when building from a tarball (generated by `git archive`) it does not work, since there are no files managed by VCS. Adding the package explicitly helps for this case.

[1]: https://github.com/pypa/setuptools_scm/blob/v8.0.4/pyproject.toml#L72-L73
[2]: https://setuptools.pypa.io/en/latest/userguide/extension.html#adding-support-for-revision-control-systems