### PR TITLE
fix: reduce logger level

### DIFF
--- a/aiosql/aiosql.py
+++ b/aiosql/aiosql.py
@@ -35,7 +35,7 @@ _ADAPTERS: Dict[str, Callable[..., DriverAdapterProtocol]] = {
 def register_adapter(name: str, adapter: Callable[..., DriverAdapterProtocol]):
     """Register or override an adapter."""
     if name.lower() in _ADAPTERS:
-        log.warning(f"overriding aiosql adapter {name}")
+        log.debug(f"overriding aiosql adapter {name}")
     _ADAPTERS[name.lower()] = adapter
 
 


### PR DESCRIPTION
This change reduces the "override" message to a debug level message.

When I'm using a custom adapter, I am purposely doing this, so this message is an erroneous warning.  It would probably be better as a debug message.