### PR TITLE
Remove usage of cursor in DuckDB

### DIFF
--- a/aiosql/adapters/duckdb.py
+++ b/aiosql/adapters/duckdb.py
@@ -22,6 +22,11 @@ class DuckDBAdapter(GenericAdapter):
         # whether to converts the default tuple response to a dict.
         self._convert_row_to_dict = cursor_as_dict
 
+    def _cursor(self, conn):
+        """Get a cursor from a connection."""
+        # For DuckDB cursor is duplicated connection so we don't want to use it
+        return conn
+
     def process_sql(self, query_name, op_type, sql):
         return VAR_REF.sub(_colon_to_dollar, sql)
 

--- a/aiosql/adapters/duckdb.py
+++ b/aiosql/adapters/duckdb.py
@@ -45,42 +45,36 @@ class DuckDBAdapter(GenericAdapter):
     def select(self, conn, query_name: str, sql: str, parameters, record_class=None):
         column_names: List[str] = []
         cur = self._cursor(conn)
-        try:
-            cur.execute(sql, parameters)
-            if record_class is None:
-                first = True
-                for row in cur.fetchall():
-                    if first:  # get column names on the fly
-                        column_names = [c[0] for c in cur.description or []]
-                        first = False
-                    if self._convert_row_to_dict:  # pragma: no cover
-                        # strict=False: requires 3.10
-                        yield dict(zip(column_names, row))
-                    else:
-                        yield row
-            else:  # pragma: no cover
-                first = True
-                for row in cur.fetchall():
-                    if first:  # only get description on the fly, for apsw
-                        column_names = [c[0] for c in cur.description or []]
-                        first = False
+        cur.execute(sql, parameters)
+        if record_class is None:
+            first = True
+            for row in cur.fetchall():
+                if first:  # get column names on the fly
+                    column_names = [c[0] for c in cur.description or []]
+                    first = False
+                if self._convert_row_to_dict:  # pragma: no cover
                     # strict=False: requires 3.10
-                    yield record_class(**dict(zip(column_names, row)))
-        finally:
-            cur.close()
+                    yield dict(zip(column_names, row))
+                else:
+                    yield row
+        else:  # pragma: no cover
+            first = True
+            for row in cur.fetchall():
+                if first:  # only get description on the fly, for apsw
+                    column_names = [c[0] for c in cur.description or []]
+                    first = False
+                # strict=False: requires 3.10
+                yield record_class(**dict(zip(column_names, row)))
 
     def select_one(self, conn, query_name, sql, parameters, record_class=None):
         cur = self._cursor(conn)
-        try:
-            cur.execute(sql, parameters)
-            result = cur.fetchone()
-            if result is not None and record_class is not None:  # pragma: no cover
-                column_names = [c[0] for c in cur.description or []]
-                # strict=False: requires 3.10
-                result = record_class(**dict(zip(column_names, result)))
-            elif result is not None and self._convert_row_to_dict:  # pragma: no cover
-                column_names = [c[0] for c in cur.description or []]
-                result = dict(zip(column_names, result))
-        finally:
-            cur.close()
+        cur.execute(sql, parameters)
+        result = cur.fetchone()
+        if result is not None and record_class is not None:  # pragma: no cover
+            column_names = [c[0] for c in cur.description or []]
+            # strict=False: requires 3.10
+            result = record_class(**dict(zip(column_names, result)))
+        elif result is not None and self._convert_row_to_dict:  # pragma: no cover
+            column_names = [c[0] for c in cur.description or []]
+            result = dict(zip(column_names, result))
         return result


### PR DESCRIPTION
This fixes:
https://github.com/nackjicholson/aiosql/issues/203

Cursor in DuckDB is new connection. All registered objects are lost. So I'm avoiding usage of cursor.