### PR TITLE
fix: correct typos in comments and docs

### DIFF
--- a/docs/source/database-driver-adapters.rst
+++ b/docs/source/database-driver-adapters.rst
@@ -69,7 +69,7 @@ argument when building Queries:
 
     queries = aiosql.from_path("foo.sql", driver_adapter=AcmeAdapter)
 
-Alternatively, an adapter can be registered or overriden:
+Alternatively, an adapter can be registered or overridden:
 
 .. code:: python
 

--- a/docs/source/defining-sql-queries.rst
+++ b/docs/source/defining-sql-queries.rst
@@ -125,7 +125,7 @@ When used from Python this query will either return ``None`` or the singular sel
 
 The ``$`` operator will execute the query, and only return the **first value of the first row**
 of a result set. If there are no rows in the result set it returns ``None``.
-This is implemented by returing the first element of the tuple returned by ``cur.fetchone()``
+This is implemented by returning the first element of the tuple returned by ``cur.fetchone()``
 from the underlying driver.
 This is mostly useful for queries returning IDs, COUNTs or other aggregates.
 
@@ -189,7 +189,7 @@ the inserted row using
 ```cur.lastrowid`` <https://docs.python.org/3/library/sqlite3.html#sqlite3.Cursor.lastrowid>`__.
 
 As recent version of SQLite do support the ``returning`` clause, simply forget
-about this, use the clause explicitely and treat the whole command as a standard
+about this, use the clause explicitly and treat the whole command as a standard
 select with the *empty* operator (relation), or ``^`` (tuple), or ``$`` (scalar).
 
 .. literalinclude:: ../../tests/blogdb/sql/blogs/li/blogs.sql

--- a/docs/source/getting-started.rst
+++ b/docs/source/getting-started.rst
@@ -262,9 +262,9 @@ in the above query and having the resultant method expect an inbound argument to
 substitute for ``:username``.
 
 You can call the ``get_user_blogs`` function with plain arguments or keyword arguments with the
-name of the subsitution variable.
+name of the substitution variable.
 
-If a parameter list is explicitely declared, here ``(username)`` it is checked
+If a parameter list is explicitly declared, here ``(username)`` it is checked
 statically and enforced dynamically by required named parameters.
 
 .. code:: python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -190,7 +190,7 @@ application:
         # Aloha, William!
         # …
 
-Or even in an asynchroneous way, with two SQL queries running in parallel
+Or even in an asynchronous way, with two SQL queries running in parallel
 using ``aiosqlite`` and ``asyncio``:
 
 .. code:: python

--- a/docs/source/versions.rst
+++ b/docs/source/versions.rst
@@ -31,7 +31,7 @@ AioSQL - Versions
 ------------------
 
 - update GitHub CI configuration.
-- use SPDX format for licensing informations and add topics.
+- use SPDX format for licensing information and add topics.
 - doc, separate backlog from versions.
 
 13.3 on 2025-03-07
@@ -381,6 +381,6 @@ AioSQL - Versions
 2.0.0 on 2018-12-07
 -------------------
 
-- adaptater refactoring, including breaking changes.
+- adapter refactoring, including breaking changes.
 - add ``_cursor`` variants for full control.
 - remove some stuff


### PR DESCRIPTION
## Summary

Fix several typos found in the documentation using codespell:

- `asynchroneous` → `asynchronous` (docs/source/index.rst)
- `overriden` → `overridden` (docs/source/database-driver-adapters.rst)
- `returing` → `returning` (docs/source/defining-sql-queries.rst)
- `explicitely` → `explicitly` (docs/source/defining-sql-queries.rst, docs/source/getting-started.rst)
- `subsitution` → `substitution` (docs/source/getting-started.rst)
- `informations` → `information` (docs/source/versions.rst)
- `adaptater` → `adapter` (docs/source/versions.rst)

No functional changes — documentation only.